### PR TITLE
fixed pytorch losses' init documentation

### DIFF
--- a/nbs/losses.pytorch.ipynb
+++ b/nbs/losses.pytorch.ipynb
@@ -372,7 +372,7 @@
     "#| export\n",
     "class MAPE(torch.nn.Module):\n",
     "    \"\"\" Mean Absolute Percentage Error\n",
-    "\n",
+    "\
     "    Calculates Mean Absolute Percentage Error  between\n",
     "    `y` and `y_hat`. MAPE measures the relative prediction\n",
     "    accuracy of a forecasting method by calculating the percentual deviation\n",
@@ -644,7 +644,7 @@
    "id": "999d8cb2",
    "metadata": {},
    "source": [
-    "## QuantileLoss"
+    "## Quantile Loss (QL)"
    ]
   },
   {
@@ -735,7 +735,7 @@
    "id": "92dbb002",
    "metadata": {},
    "source": [
-    "## Multi Quantile Loss"
+    "## Multi Quantile Loss (MQL)"
    ]
   },
   {
@@ -893,7 +893,7 @@
    "id": "df65d575",
    "metadata": {},
    "source": [
-    "## Weighted MQLoss"
+    "## Weighted MQLoss (wMQL)"
    ]
   },
   {
@@ -1010,7 +1010,7 @@
    "id": "07f459b8",
    "metadata": {},
    "source": [
-    "## Poisson Mixture Mesh"
+    "## Poisson Mixture Mesh (PMM)"
    ]
   },
   {
@@ -1235,7 +1235,7 @@
    "id": "e84e0dd4",
    "metadata": {},
    "source": [
-    "## Gaussian Mixture Mesh"
+    "## Gaussian Mixture Mesh (GMM)"
    ]
   },
   {

--- a/nbs/losses.pytorch.ipynb
+++ b/nbs/losses.pytorch.ipynb
@@ -94,7 +94,7 @@
    "id": "82fc4679",
    "metadata": {},
    "source": [
-    "## Mean Absolute Error"
+    "## Mean Absolute Error (MAE)"
    ]
   },
   {
@@ -177,7 +177,7 @@
    "id": "4f31cc3d",
    "metadata": {},
    "source": [
-    "## Mean Squared Error"
+    "## Mean Squared Error (MSE)"
    ]
   },
   {
@@ -261,7 +261,7 @@
    "id": "b160140b",
    "metadata": {},
    "source": [
-    "## Root Mean Squared Error"
+    "## Root Mean Squared Error (RMSE)"
    ]
   },
   {
@@ -359,7 +359,7 @@
    "id": "8eab97ec",
    "metadata": {},
    "source": [
-    "## Mean Absolute Percentage Error"
+    "## Mean Absolute Percentage Error (MAPE)"
    ]
   },
   {
@@ -372,7 +372,7 @@
     "#| export\n",
     "class MAPE(torch.nn.Module):\n",
     "    \"\"\" Mean Absolute Percentage Error\n",
-    "\
+    "\n",
     "    Calculates Mean Absolute Percentage Error  between\n",
     "    `y` and `y_hat`. MAPE measures the relative prediction\n",
     "    accuracy of a forecasting method by calculating the percentual deviation\n",
@@ -444,7 +444,7 @@
    "id": "cb245891",
    "metadata": {},
    "source": [
-    "## Symmetric MAPE"
+    "## Symmetric MAPE (sMAPE)"
    ]
   },
   {
@@ -538,7 +538,7 @@
    "id": "5b2dee1f",
    "metadata": {},
    "source": [
-    "## Mean Absolute Scaled Error"
+    "## Mean Absolute Scaled Error (MASE)"
    ]
   },
   {
@@ -644,7 +644,7 @@
    "id": "999d8cb2",
    "metadata": {},
    "source": [
-    "## Quantile Loss (QL)"
+    "## Quantile Loss"
    ]
   },
   {
@@ -735,7 +735,7 @@
    "id": "92dbb002",
    "metadata": {},
    "source": [
-    "## Multi Quantile Loss (MQL)"
+    "## Multi Quantile Loss (MQLoss)"
    ]
   },
   {
@@ -893,7 +893,7 @@
    "id": "df65d575",
    "metadata": {},
    "source": [
-    "## Weighted MQLoss (wMQL)"
+    "## Weighted MQLoss (wMQLoss)"
    ]
   },
   {

--- a/nbs/losses.pytorch.ipynb
+++ b/nbs/losses.pytorch.ipynb
@@ -106,19 +106,18 @@
    "source": [
     "#| export\n",
     "class MAE(torch.nn.Module):\n",
-    "    \n",
-    "    def __init__(self):\n",
-    "        \"\"\"Mean Absolute Error\n",
+    "    \"\"\"Mean Absolute Error\n",
     "\n",
-    "        Calculates Mean Absolute Error between\n",
-    "        `y` and `y_hat`. MAE measures the relative prediction\n",
-    "        accuracy of a forecasting method by calculating the\n",
-    "        deviation of the prediction and the true\n",
-    "        value at a given time and averages these devations\n",
-    "        over the length of the series.\n",
-    "        \n",
-    "        $$ \\mathrm{MAE}(\\\\mathbf{y}_{\\\\tau}, \\\\mathbf{\\hat{y}}_{\\\\tau}) = \\\\frac{1}{H} \\\\sum^{t+H}_{\\\\tau=t+1} |y_{\\\\tau} - \\hat{y}_{\\\\tau}| $$\n",
-    "        \"\"\"\n",
+    "    Calculates Mean Absolute Error between\n",
+    "    `y` and `y_hat`. MAE measures the relative prediction\n",
+    "    accuracy of a forecasting method by calculating the\n",
+    "    deviation of the prediction and the true\n",
+    "    value at a given time and averages these devations\n",
+    "    over the length of the series.\n",
+    "    \n",
+    "    $$ \\mathrm{MAE}(\\\\mathbf{y}_{\\\\tau}, \\\\mathbf{\\hat{y}}_{\\\\tau}) = \\\\frac{1}{H} \\\\sum^{t+H}_{\\\\tau=t+1} |y_{\\\\tau} - \\hat{y}_{\\\\tau}| $$\n",
+    "    \"\"\"    \n",
+    "    def __init__(self):\n",
     "        super(MAE, self).__init__()\n",
     "        self.outputsize_multiplier = 1\n",
     "        self.output_names = ['']\n",
@@ -162,7 +161,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "show_doc(MAE.__call__, name='MAE', title_level=3)"
+    "show_doc(MAE.__call__, name='MAE.__call__', title_level=3)"
    ]
   },
   {
@@ -190,19 +189,18 @@
    "source": [
     "#| export\n",
     "class MSE(torch.nn.Module):\n",
-    "    \n",
-    "    def __init__(self):\n",
-    "        \"\"\"  Mean Squared Error\n",
+    "    \"\"\"  Mean Squared Error\n",
     "\n",
-    "        Calculates Mean Squared Error between\n",
-    "        `y` and `y_hat`. MSE measures the relative prediction\n",
-    "        accuracy of a forecasting method by calculating the \n",
-    "        squared deviation of the prediction and the true\n",
-    "        value at a given time, and averages these devations\n",
-    "        over the length of the series.\n",
-    "        \n",
-    "        $$ \\mathrm{MSE}(\\\\mathbf{y}_{\\\\tau}, \\\\mathbf{\\hat{y}}_{\\\\tau}) = \\\\frac{1}{H} \\\\sum^{t+H}_{\\\\tau=t+1} (y_{\\\\tau} - \\hat{y}_{\\\\tau})^{2} $$\n",
-    "        \"\"\"\n",
+    "    Calculates Mean Squared Error between\n",
+    "    `y` and `y_hat`. MSE measures the relative prediction\n",
+    "    accuracy of a forecasting method by calculating the \n",
+    "    squared deviation of the prediction and the true\n",
+    "    value at a given time, and averages these devations\n",
+    "    over the length of the series.\n",
+    "    \n",
+    "    $$ \\mathrm{MSE}(\\\\mathbf{y}_{\\\\tau}, \\\\mathbf{\\hat{y}}_{\\\\tau}) = \\\\frac{1}{H} \\\\sum^{t+H}_{\\\\tau=t+1} (y_{\\\\tau} - \\hat{y}_{\\\\tau})^{2} $$\n",
+    "    \"\"\"    \n",
+    "    def __init__(self):\n",
     "        super(MSE, self).__init__()\n",
     "        self.outputsize_multiplier = 1\n",
     "        self.output_names = ['']\n",
@@ -247,7 +245,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "show_doc(MSE.__call__, name='MSE', title_level=3)"
+    "show_doc(MSE.__call__, name='MSE.__call__', title_level=3)"
    ]
   },
   {
@@ -275,22 +273,21 @@
    "source": [
     "#| export\n",
     "class RMSE(torch.nn.Module):\n",
-    "    \n",
-    "    def __init__(self):\n",
-    "        \"\"\" Root Mean Squared Error\n",
+    "    \"\"\" Root Mean Squared Error\n",
     "\n",
-    "        Calculates Root Mean Squared Error between\n",
-    "        `y` and `y_hat`. RMSE measures the relative prediction\n",
-    "        accuracy of a forecasting method by calculating the squared deviation\n",
-    "        of the prediction and the observed value at a given time and\n",
-    "        averages these devations over the length of the series.\n",
-    "        Finally the RMSE will be in the same scale\n",
-    "        as the original time series so its comparison with other\n",
-    "        series is possible only if they share a common scale. \n",
-    "        RMSE has a direct connection to the L2 norm.\n",
-    "        \n",
-    "        $$ \\mathrm{RMSE}(\\\\mathbf{y}_{\\\\tau}, \\\\mathbf{\\hat{y}}_{\\\\tau}) = \\\\sqrt{\\\\frac{1}{H} \\\\sum^{t+H}_{\\\\tau=t+1} (y_{\\\\tau} - \\hat{y}_{\\\\tau})^{2}} $$\n",
-    "        \"\"\"\n",
+    "    Calculates Root Mean Squared Error between\n",
+    "    `y` and `y_hat`. RMSE measures the relative prediction\n",
+    "    accuracy of a forecasting method by calculating the squared deviation\n",
+    "    of the prediction and the observed value at a given time and\n",
+    "    averages these devations over the length of the series.\n",
+    "    Finally the RMSE will be in the same scale\n",
+    "    as the original time series so its comparison with other\n",
+    "    series is possible only if they share a common scale. \n",
+    "    RMSE has a direct connection to the L2 norm.\n",
+    "    \n",
+    "    $$ \\mathrm{RMSE}(\\\\mathbf{y}_{\\\\tau}, \\\\mathbf{\\hat{y}}_{\\\\tau}) = \\\\sqrt{\\\\frac{1}{H} \\\\sum^{t+H}_{\\\\tau=t+1} (y_{\\\\tau} - \\hat{y}_{\\\\tau})^{2}} $$\n",
+    "    \"\"\"\n",
+    "    def __init__(self):\n",
     "        super(RMSE, self).__init__()\n",
     "        self.outputsize_multiplier = 1\n",
     "        self.output_names = ['']\n",
@@ -326,7 +323,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "show_doc(MSE, name='RMSE.__init__', title_level=3)"
+    "show_doc(RMSE, name='RMSE.__init__', title_level=3)"
    ]
   },
   {
@@ -336,7 +333,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "show_doc(RMSE.__call__, name='RMSE', title_level=3)"
+    "show_doc(RMSE.__call__, name='RMSE.__call__', title_level=3)"
    ]
   },
   {
@@ -374,20 +371,19 @@
    "source": [
     "#| export\n",
     "class MAPE(torch.nn.Module):\n",
-    "    \n",
-    "    def __init__(self):\n",
-    "        \"\"\" Mean Absolute Percentage Error\n",
+    "    \"\"\" Mean Absolute Percentage Error\n",
     "\n",
-    "        Calculates Mean Absolute Percentage Error  between\n",
-    "        `y` and `y_hat`. MAPE measures the relative prediction\n",
-    "        accuracy of a forecasting method by calculating the percentual deviation\n",
-    "        of the prediction and the observed value at a given time and\n",
-    "        averages these devations over the length of the series.\n",
-    "        The closer to zero an observed value is, the higher penalty MAPE loss\n",
-    "        assigns to the corresponding error.\n",
-    "        \n",
-    "        $$ \\mathrm{MAPE}(\\\\mathbf{y}_{\\\\tau}, \\\\mathbf{\\hat{y}}_{\\\\tau}) = \\\\frac{1}{H} \\\\sum^{t+H}_{\\\\tau=t+1} \\\\frac{|y_{\\\\tau}-\\hat{y}_{\\\\tau}|}{|y_{\\\\tau}|} $$\n",
-    "        \"\"\"\n",
+    "    Calculates Mean Absolute Percentage Error  between\n",
+    "    `y` and `y_hat`. MAPE measures the relative prediction\n",
+    "    accuracy of a forecasting method by calculating the percentual deviation\n",
+    "    of the prediction and the observed value at a given time and\n",
+    "    averages these devations over the length of the series.\n",
+    "    The closer to zero an observed value is, the higher penalty MAPE loss\n",
+    "    assigns to the corresponding error.\n",
+    "    \n",
+    "    $$ \\mathrm{MAPE}(\\\\mathbf{y}_{\\\\tau}, \\\\mathbf{\\hat{y}}_{\\\\tau}) = \\\\frac{1}{H} \\\\sum^{t+H}_{\\\\tau=t+1} \\\\frac{|y_{\\\\tau}-\\hat{y}_{\\\\tau}|}{|y_{\\\\tau}|} $$\n",
+    "    \"\"\"    \n",
+    "    def __init__(self):\n",
     "        super(MAPE, self).__init__()\n",
     "        self.outputsize_multiplier = 1\n",
     "        self.output_names = ['']\n",
@@ -432,7 +428,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "show_doc(MAPE, name='MAPE.__call__', title_level=3)"
+    "show_doc(MAPE.__call__, name='MAPE.__call__', title_level=3)"
    ]
   },
   {
@@ -448,7 +444,7 @@
    "id": "cb245891",
    "metadata": {},
    "source": [
-    "## SMAPE"
+    "## Symmetric MAPE"
    ]
   },
   {
@@ -460,24 +456,24 @@
    "source": [
     "#| export\n",
     "class SMAPE(torch.nn.Module):\n",
+    "    \"\"\" Symmetric Mean Absolute Percentage Error\n",
+    "\n",
+    "    Calculates Symmetric Mean Absolute Percentage Error between\n",
+    "    `y` and `y_hat`. SMAPE measures the relative prediction\n",
+    "    accuracy of a forecasting method by calculating the relative deviation\n",
+    "    of the prediction and the observed value scaled by the sum of the\n",
+    "    absolute values for the prediction and observed value at a\n",
+    "    given time, then averages these devations over the length\n",
+    "    of the series. This allows the SMAPE to have bounds between\n",
+    "    0% and 200% which is desireble compared to normal MAPE that\n",
+    "    may be undetermined when the target is zero.\n",
+    "\n",
+    "    $$ \\mathrm{sMAPE}_{2}(\\\\mathbf{y}_{\\\\tau}, \\\\mathbf{\\hat{y}}_{\\\\tau}) = \\\\frac{1}{H} \\\\sum^{t+H}_{\\\\tau=t+1} \\\\frac{|y_{\\\\tau}-\\hat{y}_{\\\\tau}|}{|y_{\\\\tau}|+|\\hat{y}_{\\\\tau}|} $$\n",
+    "\n",
+    "    **References:**<br>\n",
+    "    [Makridakis S., \"Accuracy measures: theoretical and practical concerns\".](https://www.sciencedirect.com/science/article/pii/0169207093900793)\n",
+    "    \"\"\"\n",
     "    def __init__(self):\n",
-    "        \"\"\" Symmetric Mean Absolute Percentage Error\n",
-    "        \n",
-    "        Calculates Symmetric Mean Absolute Percentage Error between\n",
-    "        `y` and `y_hat`. SMAPE measures the relative prediction\n",
-    "        accuracy of a forecasting method by calculating the relative deviation\n",
-    "        of the prediction and the observed value scaled by the sum of the\n",
-    "        absolute values for the prediction and observed value at a\n",
-    "        given time, then averages these devations over the length\n",
-    "        of the series. This allows the SMAPE to have bounds between\n",
-    "        0% and 200% which is desireble compared to normal MAPE that\n",
-    "        may be undetermined when the target is zero.\n",
-    "        \n",
-    "        $$ \\mathrm{sMAPE}_{2}(\\\\mathbf{y}_{\\\\tau}, \\\\mathbf{\\hat{y}}_{\\\\tau}) = \\\\frac{1}{H} \\\\sum^{t+H}_{\\\\tau=t+1} \\\\frac{|y_{\\\\tau}-\\hat{y}_{\\\\tau}|}{|y_{\\\\tau}|+|\\hat{y}_{\\\\tau}|} $$\n",
-    "        \n",
-    "        **References:**<br>\n",
-    "        [Makridakis S., \"Accuracy measures: theoretical and practical concerns\".](https://www.sciencedirect.com/science/article/pii/0169207093900793)\n",
-    "        \"\"\"\n",
     "        super(SMAPE, self).__init__()\n",
     "        self.outputsize_multiplier = 1\n",
     "        self.output_names = ['']\n",
@@ -514,7 +510,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "show_doc(SMAPE, name='SMAPE.__init__')"
+    "show_doc(SMAPE, name='SMAPE.__init__', title_level=3)"
    ]
   },
   {
@@ -524,7 +520,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "show_doc(SMAPE.__call__, name='SMAPE')"
+    "show_doc(SMAPE.__call__, name='SMAPE.__call__', title_level=3)"
    ]
   },
   {
@@ -554,26 +550,25 @@
    "source": [
     "#| export\n",
     "class MASE(torch.nn.Module):\n",
+    "    \"\"\" Mean Absolute Scaled Error \n",
+    "    Calculates the Mean Absolute Scaled Error between\n",
+    "    `y` and `y_hat`. MASE measures the relative prediction\n",
+    "    accuracy of a forecasting method by comparinng the mean absolute errors\n",
+    "    of the prediction and the observed value against the mean\n",
+    "    absolute errors of the seasonal naive model.\n",
+    "    The MASE partially composed the Overall Weighted Average (OWA), \n",
+    "    used in the M4 Competition.\n",
+    "    \n",
+    "    $$ \\mathrm{MASE}(\\\\mathbf{y}_{\\\\tau}, \\\\mathbf{\\hat{y}}_{\\\\tau}, \\\\mathbf{\\hat{y}}^{season}_{\\\\tau}) = \\\\frac{1}{H} \\sum^{t+H}_{\\\\tau=t+1} \\\\frac{|y_{\\\\tau}-\\hat{y}_{\\\\tau}|}{\\mathrm{MAE}(\\\\mathbf{y}_{\\\\tau}, \\\\mathbf{\\hat{y}}^{season}_{\\\\tau})} $$\n",
     "\n",
+    "    **Parameters:**<br>\n",
+    "    `seasonality`: int. Main frequency of the time series; Hourly 24,  Daily 7, Weekly 52, Monthly 12, Quarterly 4, Yearly 1.\n",
+    "    \n",
+    "    **References:**<br>\n",
+    "    [Rob J. Hyndman, & Koehler, A. B. \"Another look at measures of forecast accuracy\".](https://www.sciencedirect.com/science/article/pii/S0169207006000239)<br>\n",
+    "    [Spyros Makridakis, Evangelos Spiliotis, Vassilios Assimakopoulos, \"The M4 Competition: 100,000 time series and 61 forecasting methods\".](https://www.sciencedirect.com/science/article/pii/S0169207019301128)\n",
+    "    \"\"\"\n",
     "    def __init__(self, seasonality: int):\n",
-    "        \"\"\" Mean Absolute Scaled Error \n",
-    "        Calculates the Mean Absolute Scaled Error between\n",
-    "        `y` and `y_hat`. MASE measures the relative prediction\n",
-    "        accuracy of a forecasting method by comparinng the mean absolute errors\n",
-    "        of the prediction and the observed value against the mean\n",
-    "        absolute errors of the seasonal naive model.\n",
-    "        The MASE partially composed the Overall Weighted Average (OWA), \n",
-    "        used in the M4 Competition.\n",
-    "        \n",
-    "        $$ \\mathrm{MASE}(\\\\mathbf{y}_{\\\\tau}, \\\\mathbf{\\hat{y}}_{\\\\tau}, \\\\mathbf{\\hat{y}}^{season}_{\\\\tau}) = \\\\frac{1}{H} \\sum^{t+H}_{\\\\tau=t+1} \\\\frac{|y_{\\\\tau}-\\hat{y}_{\\\\tau}|}{\\mathrm{MAE}(\\\\mathbf{y}_{\\\\tau}, \\\\mathbf{\\hat{y}}^{season}_{\\\\tau})} $$\n",
-    "\n",
-    "        **Parameters:**<br>\n",
-    "        `seasonality`: int. Main frequency of the time series; Hourly 24,  Daily 7, Weekly 52, Monthly 12, Quarterly 4, Yearly 1.\n",
-    "        \n",
-    "        **References:**<br>\n",
-    "        [Rob J. Hyndman, & Koehler, A. B. \"Another look at measures of forecast accuracy\".](https://www.sciencedirect.com/science/article/pii/S0169207006000239)<br>\n",
-    "        [Spyros Makridakis, Evangelos Spiliotis, Vassilios Assimakopoulos, \"The M4 Competition: 100,000 time series and 61 forecasting methods\".](https://www.sciencedirect.com/science/article/pii/S0169207019301128)\n",
-    "        \"\"\"\n",
     "        super(MASE, self).__init__()\n",
     "        self.seasonality = seasonality\n",
     "        self.outputsize_multiplier = 1\n",
@@ -623,7 +618,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "show_doc(MASE.__call__, name='MASE', title_level=3)"
+    "show_doc(MASE.__call__, name='MASE.__call__', title_level=3)"
    ]
   },
   {
@@ -661,24 +656,23 @@
    "source": [
     "#| export\n",
     "class QuantileLoss(torch.nn.Module):\n",
-    "    \n",
+    "    \"\"\" Quantile Loss\n",
+    "\n",
+    "    Computes the quantile loss between `y` and `y_hat`.\n",
+    "    QL measures the deviation of a quantile forecast.\n",
+    "    By weighting the absolute deviation in a non symmetric way, the\n",
+    "    loss pays more attention to under or over estimation.\n",
+    "    A common value for q is 0.5 for the deviation from the median (Pinball loss).\n",
+    "\n",
+    "    $$ \\mathrm{QL}(\\\\mathbf{y}_{\\\\tau}, \\\\mathbf{\\hat{y}}^{(q)}_{\\\\tau}) = \\\\frac{1}{H} \\\\sum^{t+H}_{\\\\tau=t+1} \\Big( (1-q)\\,( \\hat{y}^{(q)}_{\\\\tau} - y_{\\\\tau} )_{+} + q\\,( y_{\\\\tau} - \\hat{y}^{(q)}_{\\\\tau} )_{+} \\Big) $$\n",
+    "\n",
+    "    **Parameters:**<br>\n",
+    "    `q`: float, between 0 and 1. The slope of the quantile loss, in the context of quantile regression, the q determines the conditional quantile level.<br>\n",
+    "\n",
+    "    **References:**<br>\n",
+    "    [Roger Koenker and Gilbert Bassett, Jr., \"Regression Quantiles\".](https://www.jstor.org/stable/1913643)\n",
+    "    \"\"\"\n",
     "    def __init__(self, q):\n",
-    "        \"\"\" Quantile Loss\n",
-    "\n",
-    "        Computes the quantile loss between `y` and `y_hat`.\n",
-    "        QL measures the deviation of a quantile forecast.\n",
-    "        By weighting the absolute deviation in a non symmetric way, the\n",
-    "        loss pays more attention to under or over estimation.\n",
-    "        A common value for q is 0.5 for the deviation from the median (Pinball loss).\n",
-    "\n",
-    "        $$ \\mathrm{QL}(\\\\mathbf{y}_{\\\\tau}, \\\\mathbf{\\hat{y}}^{(q)}_{\\\\tau}) = \\\\frac{1}{H} \\\\sum^{t+H}_{\\\\tau=t+1} \\Big( (1-q)\\,( \\hat{y}^{(q)}_{\\\\tau} - y_{\\\\tau} )_{+} + q\\,( y_{\\\\tau} - \\hat{y}^{(q)}_{\\\\tau} )_{+} \\Big) $$\n",
-    "\n",
-    "        **Parameters:**<br>\n",
-    "        `q`: float, between 0 and 1. The slope of the quantile loss, in the context of quantile regression, the q determines the conditional quantile level.<br>\n",
-    "\n",
-    "        **References:**<br>\n",
-    "        [Roger Koenker and Gilbert Bassett, Jr., \"Regression Quantiles\".](https://www.jstor.org/stable/1913643)\n",
-    "        \"\"\"\n",
     "        super(QuantileLoss, self).__init__()\n",
     "        self.q = q\n",
     "        self.outputsize_multiplier = 1\n",
@@ -715,7 +709,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "show_doc(QuantileLoss, name='QuantileLoss.__init__')"
+    "show_doc(QuantileLoss, name='QuantileLoss.__init__', title_level=3)"
    ]
   },
   {
@@ -725,7 +719,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "show_doc(QuantileLoss.__call__, name='QuantileLoss')"
+    "show_doc(QuantileLoss.__call__, name='QuantileLoss.__call__', title_level=3)"
    ]
   },
   {
@@ -741,7 +735,7 @@
    "id": "92dbb002",
    "metadata": {},
    "source": [
-    "## MQLoss"
+    "## Multi Quantile Loss"
    ]
   },
   {
@@ -788,34 +782,33 @@
    "source": [
     "#| export\n",
     "class MQLoss(torch.nn.Module):\n",
+    "    \"\"\"  Multi-Quantile loss\n",
+    "\n",
+    "    Calculates the Multi-Quantile loss (MQL) between `y` and `y_hat`.\n",
+    "    MQL calculates the average multi-quantile Loss for\n",
+    "    a given set of quantiles, based on the absolute \n",
+    "    difference between predicted quantiles and observed values.\n",
     "    \n",
+    "    $$ \\mathrm{MQL}(\\\\mathbf{y}_{\\\\tau},[\\\\mathbf{\\hat{y}}^{(q_{1})}_{\\\\tau}, ... ,\\hat{y}^{(q_{n})}_{\\\\tau}]) = \\\\frac{1}{n} \\\\sum_{q_{i}} \\mathrm{QL}(\\\\mathbf{y}_{\\\\tau}, \\\\mathbf{\\hat{y}}^{(q_{i})}_{\\\\tau}) $$\n",
+    "    \n",
+    "    The limit behavior of MQL allows to measure the accuracy \n",
+    "    of a full predictive distribution $\\mathbf{\\hat{F}}_{\\\\tau}$ with \n",
+    "    the continuous ranked probability score (CRPS). This can be achieved \n",
+    "    through a numerical integration technique, that discretizes the quantiles \n",
+    "    and treats the CRPS integral with a left Riemann approximation, averaging over \n",
+    "    uniformly distanced quantiles.    \n",
+    "    \n",
+    "    $$ \\mathrm{CRPS}(y_{\\\\tau}, \\mathbf{\\hat{F}}_{\\\\tau}) = \\int^{1}_{0} \\mathrm{QL}(y_{\\\\tau}, \\hat{y}^{(q)}_{\\\\tau}) dq $$\n",
+    "\n",
+    "    **Parameters:**<br>\n",
+    "    `level`: int list [0,100]. Probability levels for prediction intervals (Defaults median).\n",
+    "    `quantiles`: float list [0., 1.]. Alternative to level, quantiles to estimate from y distribution.\n",
+    "\n",
+    "    **References:**<br>\n",
+    "    [Roger Koenker and Gilbert Bassett, Jr., \"Regression Quantiles\".](https://www.jstor.org/stable/1913643)<br>\n",
+    "    [James E. Matheson and Robert L. Winkler, \"Scoring Rules for Continuous Probability Distributions\".](https://www.jstor.org/stable/2629907)\n",
+    "    \"\"\"\n",
     "    def __init__(self, level=[80, 90], quantiles=None):\n",
-    "        \"\"\"  Multi-Quantile loss\n",
-    "    \n",
-    "        Calculates the Multi-Quantile loss (MQL) between `y` and `y_hat`.\n",
-    "        MQL calculates the average multi-quantile Loss for\n",
-    "        a given set of quantiles, based on the absolute \n",
-    "        difference between predicted quantiles and observed values.\n",
-    "        \n",
-    "        $$ \\mathrm{MQL}(\\\\mathbf{y}_{\\\\tau},[\\\\mathbf{\\hat{y}}^{(q_{1})}_{\\\\tau}, ... ,\\hat{y}^{(q_{n})}_{\\\\tau}]) = \\\\frac{1}{n} \\\\sum_{q_{i}} \\mathrm{QL}(\\\\mathbf{y}_{\\\\tau}, \\\\mathbf{\\hat{y}}^{(q_{i})}_{\\\\tau}) $$\n",
-    "        \n",
-    "        The limit behavior of MQL allows to measure the accuracy \n",
-    "        of a full predictive distribution $\\mathbf{\\hat{F}}_{\\\\tau}$ with \n",
-    "        the continuous ranked probability score (CRPS). This can be achieved \n",
-    "        through a numerical integration technique, that discretizes the quantiles \n",
-    "        and treats the CRPS integral with a left Riemann approximation, averaging over \n",
-    "        uniformly distanced quantiles.    \n",
-    "        \n",
-    "        $$ \\mathrm{CRPS}(y_{\\\\tau}, \\mathbf{\\hat{F}}_{\\\\tau}) = \\int^{1}_{0} \\mathrm{QL}(y_{\\\\tau}, \\hat{y}^{(q)}_{\\\\tau}) dq $$\n",
-    "\n",
-    "        **Parameters:**<br>\n",
-    "        `level`: int list [0,100]. Probability levels for prediction intervals (Defaults median).\n",
-    "        `quantiles`: float list [0., 1.]. Alternative to level, quantiles to estimate from y distribution.\n",
-    "\n",
-    "        **References:**<br>\n",
-    "        [Roger Koenker and Gilbert Bassett, Jr., \"Regression Quantiles\".](https://www.jstor.org/stable/1913643)<br>\n",
-    "        [James E. Matheson and Robert L. Winkler, \"Scoring Rules for Continuous Probability Distributions\".](https://www.jstor.org/stable/2629907)\n",
-    "        \"\"\"\n",
     "        super(MQLoss, self).__init__()\n",
     "        # Transform level to MQLoss parameters\n",
     "        if level:\n",
@@ -874,7 +867,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "show_doc(MQLoss, name='MQLoss.__init__')"
+    "show_doc(MQLoss, name='MQLoss.__init__', title_level=3)"
    ]
   },
   {
@@ -884,7 +877,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "show_doc(MQLoss.__call__, name='MQLoss')"
+    "show_doc(MQLoss.__call__, name='MQLoss.__call__', title_level=3)"
    ]
   },
   {
@@ -900,7 +893,7 @@
    "id": "df65d575",
    "metadata": {},
    "source": [
-    "## wMQ Loss"
+    "## Weighted MQLoss"
    ]
   },
   {
@@ -912,25 +905,24 @@
    "source": [
     "#| export\n",
     "class wMQLoss(torch.nn.Module):\n",
+    "    \"\"\" Weighted Multi-Quantile loss\n",
     "    \n",
-    "    def __init__(self, level=[80, 90], quantiles=None):\n",
-    "        \"\"\" Weighted Multi-Quantile loss\n",
+    "    Calculates the Weighted Multi-Quantile loss (WMQL) between `y` and `y_hat`.\n",
+    "    WMQL calculates the weighted average multi-quantile Loss for\n",
+    "    a given set of quantiles, based on the absolute \n",
+    "    difference between predicted quantiles and observed values.  \n",
     "        \n",
-    "        Calculates the Weighted Multi-Quantile loss (WMQL) between `y` and `y_hat`.\n",
-    "        WMQL calculates the weighted average multi-quantile Loss for\n",
-    "        a given set of quantiles, based on the absolute \n",
-    "        difference between predicted quantiles and observed values.  \n",
-    "            \n",
-    "        $$ \\mathrm{wMQL}(\\\\mathbf{y}_{\\\\tau},[\\\\mathbf{\\hat{y}}^{(q_{1})}_{\\\\tau}, ... ,\\hat{y}^{(q_{n})}_{\\\\tau}]) = \\\\frac{1}{n} \\\\sum_{q_{i}} \\\\frac{\\mathrm{QL}(\\\\mathbf{y}_{\\\\tau}, \\\\mathbf{\\hat{y}}^{(q_{i})}_{\\\\tau})}{\\\\sum^{t+H}_{\\\\tau=t+1} |y_{\\\\tau}|} $$\n",
-    "        \n",
-    "        **Parameters:**<br>\n",
-    "        `level`: int list [0,100]. Probability levels for prediction intervals (Defaults median).\n",
-    "        `quantiles`: float list [0., 1.]. Alternative to level, quantiles to estimate from y distribution.\n",
+    "    $$ \\mathrm{wMQL}(\\\\mathbf{y}_{\\\\tau},[\\\\mathbf{\\hat{y}}^{(q_{1})}_{\\\\tau}, ... ,\\hat{y}^{(q_{n})}_{\\\\tau}]) = \\\\frac{1}{n} \\\\sum_{q_{i}} \\\\frac{\\mathrm{QL}(\\\\mathbf{y}_{\\\\tau}, \\\\mathbf{\\hat{y}}^{(q_{i})}_{\\\\tau})}{\\\\sum^{t+H}_{\\\\tau=t+1} |y_{\\\\tau}|} $$\n",
+    "    \n",
+    "    **Parameters:**<br>\n",
+    "    `level`: int list [0,100]. Probability levels for prediction intervals (Defaults median).\n",
+    "    `quantiles`: float list [0., 1.]. Alternative to level, quantiles to estimate from y distribution.\n",
     "\n",
-    "        **References:**<br>\n",
-    "        [Roger Koenker and Gilbert Bassett, Jr., \"Regression Quantiles\".](https://www.jstor.org/stable/1913643)<br>\n",
-    "        [James E. Matheson and Robert L. Winkler, \"Scoring Rules for Continuous Probability Distributions\".](https://www.jstor.org/stable/2629907)\n",
-    "        \"\"\"\n",
+    "    **References:**<br>\n",
+    "    [Roger Koenker and Gilbert Bassett, Jr., \"Regression Quantiles\".](https://www.jstor.org/stable/1913643)<br>\n",
+    "    [James E. Matheson and Robert L. Winkler, \"Scoring Rules for Continuous Probability Distributions\".](https://www.jstor.org/stable/2629907)\n",
+    "    \"\"\"\n",
+    "    def __init__(self, level=[80, 90], quantiles=None):\n",
     "        super(wMQLoss, self).__init__()\n",
     "        # Transform level to MQLoss parameters\n",
     "        if level:\n",
@@ -986,7 +978,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "show_doc(wMQLoss, name='wMQLoss.__init__')"
+    "show_doc(wMQLoss, name='wMQLoss.__init__', title_level=3)"
    ]
   },
   {
@@ -996,7 +988,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "show_doc(wMQLoss.__call__, name='wMQLoss')"
+    "show_doc(wMQLoss.__call__, name='wMQLoss.__call__', title_level=3)"
    ]
   },
   {
@@ -1030,23 +1022,22 @@
    "source": [
     "#| export\n",
     "class PMM(torch.nn.Module):\n",
+    "    \"\"\" Poisson Mixture Mesh\n",
     "\n",
+    "    This Poisson Mixture statistical model assumes independence across groups of \n",
+    "    data $\\mathcal{G}=\\{[g_{i}]\\}$, and estimates relationships within the group.\n",
+    "\n",
+    "    $$ \\mathrm{P}\\\\left(\\mathbf{y}_{[b][t+1:t+H]}\\\\right) = \n",
+    "    \\prod_{ [g_{i}] \\in \\mathcal{G}} \\mathrm{P} \\\\left(\\mathbf{y}_{[g_{i}][\\\\tau]} \\\\right) =\n",
+    "    \\prod_{\\\\beta\\in[g_{i}]} \n",
+    "    \\\\left(\\sum_{k=1}^{K} w_k \\prod_{(\\\\beta,\\\\tau) \\in [g_i][t+1:t+H]} \\mathrm{Poisson}(y_{\\\\beta,\\\\tau}, \\hat{\\\\lambda}_{\\\\beta,\\\\tau,k}) \\\\right)$$\n",
+    "\n",
+    "    **References:**<br>\n",
+    "    [Kin G. Olivares, O. Nganba Meetei, Ruijun Ma, Rohan Reddy, Mengfei Cao, Lee Dicker. \n",
+    "    Probabilistic Hierarchical Forecasting with Deep Poisson Mixtures. Submitted to the International \n",
+    "    Journal Forecasting, Working paper available at arxiv.](https://arxiv.org/pdf/2110.13179.pdf)\n",
+    "    \"\"\"\n",
     "    def __init__(self, level=[80, 90], quantiles=None):\n",
-    "        \"\"\" Poisson Mixture Mesh\n",
-    "\n",
-    "        This Poisson Mixture statistical model assumes independence across groups of \n",
-    "        data $\\mathcal{G}=\\{[g_{i}]\\}$, and estimates relationships within the group.\n",
-    "\n",
-    "        $$ P\\\\left(\\mathbf{y}_{[b][t+1:t+H]}\\\\right) = \n",
-    "        \\prod_{ [g_{i}] \\in \\mathcal{G}} P \\\\left(\\mathbf{y}_{[g_{i}][\\\\tau]} \\\\right) =\n",
-    "        \\prod_{\\\\beta\\in[g_{i}]} \n",
-    "        \\\\left(\\sum_{k=1}^{K} w_k \\prod_{(\\\\beta,\\\\tau) \\in [g_i][t+1:t+H]} \\mathrm{Poisson}(y_{\\\\beta,\\\\tau}, \\hat{\\\\lambda}_{\\\\beta,\\\\tau,k}) \\\\right)$$\n",
-    "\n",
-    "        **References:**<br>\n",
-    "        [Kin G. Olivares, O. Nganba Meetei, Ruijun Ma, Rohan Reddy, Mengfei Cao, Lee Dicker. \n",
-    "        Probabilistic Hierarchical Forecasting with Deep Poisson Mixtures. Submitted to the International \n",
-    "        Journal Forecasting, Working paper available at arxiv.](https://arxiv.org/pdf/2110.13179.pdf)\n",
-    "        \"\"\"\n",
     "        super(PMM, self).__init__()\n",
     "        # Transform level to MQLoss parameters\n",
     "        if level:\n",
@@ -1141,10 +1132,41 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "62d7daba",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_doc(PMM, name='PMM.__init__', title_level=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fa8da65c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_doc(PMM.sample, name='PMM.sample', title_level=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ba75717c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_doc(PMM.__call__, name='PMM.__call__', title_level=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "fba6a127",
    "metadata": {},
    "outputs": [],
    "source": [
+    "#| hide\n",
     "# Create single mixture and broadcast to N,H,K\n",
     "weights = torch.ones((1,3))[None, :, :]\n",
     "lambdas = torch.Tensor([[5,10,15], [10,20,30]])[None, :, :]\n",
@@ -1165,6 +1187,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#| hide\n",
     "model = PMM(quantiles=[0.1, 0.40, 0.5, 0.60, 0.9])\n",
     "\n",
     "samples, quants = model.sample(weights=weights,\n",
@@ -1224,24 +1247,23 @@
    "source": [
     "#| export\n",
     "class GMM(torch.nn.Module):\n",
+    "    \"\"\" Gaussian Mixture Mesh\n",
     "\n",
+    "    This Gaussian Mixture statistical model assumes independence across groups of \n",
+    "    data $\\mathcal{G}=\\{[g_{i}]\\}$, and estimates relationships within the group.\n",
+    "\n",
+    "    $$ \\mathrm{P}\\\\left(\\mathbf{y}_{[b][t+1:t+H]}\\\\right) = \n",
+    "    \\prod_{ [g_{i}] \\in \\mathcal{G}} \\mathrm{P}\\left(\\mathbf{y}_{[g_{i}][\\\\tau]}\\\\right)=\n",
+    "    \\prod_{\\\\beta\\in[g_{i}]}\n",
+    "    \\\\left(\\sum_{k=1}^{K} w_k \\prod_{(\\\\beta,\\\\tau) \\in [g_i][t+1:t+H]} \n",
+    "    \\mathrm{Gaussian}(y_{\\\\beta,\\\\tau}, \\hat{\\mu}_{\\\\beta,\\\\tau,k}, \\sigma_{\\\\beta,\\\\tau,k})\\\\right)$$\n",
+    "\n",
+    "    **References:**<br>\n",
+    "    [Kin G. Olivares, O. Nganba Meetei, Ruijun Ma, Rohan Reddy, Mengfei Cao, Lee Dicker. \n",
+    "    Probabilistic Hierarchical Forecasting with Deep Poisson Mixtures. Submitted to the International \n",
+    "    Journal Forecasting, Working paper available at arxiv.](https://arxiv.org/pdf/2110.13179.pdf)\n",
+    "    \"\"\"\n",
     "    def __init__(self, level=[80, 90], quantiles=None):\n",
-    "        \"\"\" Gaussian Mixture Mesh\n",
-    "\n",
-    "        This Gaussian Mixture statistical model assumes independence across groups of \n",
-    "        data $\\mathcal{G}=\\{[g_{i}]\\}$, and estimates relationships within the group.\n",
-    "\n",
-    "        $$ P\\\\left(\\mathbf{y}_{[b][t+1:t+H]}\\\\right) = \n",
-    "        \\prod_{ [g_{i}] \\in \\mathcal{G}} P\\left(\\mathbf{y}_{[g_{i}][\\\\tau]}\\\\right)=\n",
-    "        \\prod_{\\\\beta\\in[g_{i}]}\n",
-    "        \\\\left(\\sum_{k=1}^{K} w_k \\prod_{(\\\\beta,\\\\tau) \\in [g_i][t+1:t+H]} \n",
-    "        \\mathrm{Gaussian}(y_{\\\\beta,\\\\tau}, \\hat{\\mu}_{\\\\beta,\\\\tau,k}, \\sigma_{\\\\beta,\\\\tau,k})\\\\right)$$\n",
-    "\n",
-    "        **References:**<br>\n",
-    "        [Kin G. Olivares, O. Nganba Meetei, Ruijun Ma, Rohan Reddy, Mengfei Cao, Lee Dicker. \n",
-    "        Probabilistic Hierarchical Forecasting with Deep Poisson Mixtures. Submitted to the International \n",
-    "        Journal Forecasting, Working paper available at arxiv.](https://arxiv.org/pdf/2110.13179.pdf)\n",
-    "        \"\"\"\n",
     "        super(GMM, self).__init__()\n",
     "        # Transform level to MQLoss parameters\n",
     "        if level:\n",
@@ -1343,10 +1365,41 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "ec4ebf3d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_doc(GMM, name='GMM.__init__', title_level=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bea56d8d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_doc(GMM.sample, name='GMM.sample', title_level=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5f16e4f7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_doc(GMM.__call__, name='GMM.__call__', title_level=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "5493e651",
    "metadata": {},
    "outputs": [],
    "source": [
+    "#| hide\n",
     "# Create single mixture and broadcast to N,H,K\n",
     "means   = torch.Tensor([[5,10,15], [10,20,30]])[None, :, :]\n",
     "\n",
@@ -1368,6 +1421,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#| hide\n",
     "model = GMM(quantiles=[0.1, 0.40, 0.5, 0.60, 0.9])\n",
     "\n",
     "samples, quants = model.sample(weights=weights,\n",

--- a/neuralforecast/losses/pytorch.py
+++ b/neuralforecast/losses/pytorch.py
@@ -22,19 +22,18 @@ def _divide_no_nan(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
 
 # %% ../../nbs/losses.pytorch.ipynb 8
 class MAE(torch.nn.Module):
-    
-    def __init__(self):
-        """Mean Absolute Error
+    """Mean Absolute Error
 
-        Calculates Mean Absolute Error between
-        `y` and `y_hat`. MAE measures the relative prediction
-        accuracy of a forecasting method by calculating the
-        deviation of the prediction and the true
-        value at a given time and averages these devations
-        over the length of the series.
-        
-        $$ \mathrm{MAE}(\\mathbf{y}_{\\tau}, \\mathbf{\hat{y}}_{\\tau}) = \\frac{1}{H} \\sum^{t+H}_{\\tau=t+1} |y_{\\tau} - \hat{y}_{\\tau}| $$
-        """
+    Calculates Mean Absolute Error between
+    `y` and `y_hat`. MAE measures the relative prediction
+    accuracy of a forecasting method by calculating the
+    deviation of the prediction and the true
+    value at a given time and averages these devations
+    over the length of the series.
+    
+    $$ \mathrm{MAE}(\\mathbf{y}_{\\tau}, \\mathbf{\hat{y}}_{\\tau}) = \\frac{1}{H} \\sum^{t+H}_{\\tau=t+1} |y_{\\tau} - \hat{y}_{\\tau}| $$
+    """    
+    def __init__(self):
         super(MAE, self).__init__()
         self.outputsize_multiplier = 1
         self.output_names = ['']
@@ -62,19 +61,18 @@ class MAE(torch.nn.Module):
 
 # %% ../../nbs/losses.pytorch.ipynb 13
 class MSE(torch.nn.Module):
-    
-    def __init__(self):
-        """  Mean Squared Error
+    """  Mean Squared Error
 
-        Calculates Mean Squared Error between
-        `y` and `y_hat`. MSE measures the relative prediction
-        accuracy of a forecasting method by calculating the 
-        squared deviation of the prediction and the true
-        value at a given time, and averages these devations
-        over the length of the series.
-        
-        $$ \mathrm{MSE}(\\mathbf{y}_{\\tau}, \\mathbf{\hat{y}}_{\\tau}) = \\frac{1}{H} \\sum^{t+H}_{\\tau=t+1} (y_{\\tau} - \hat{y}_{\\tau})^{2} $$
-        """
+    Calculates Mean Squared Error between
+    `y` and `y_hat`. MSE measures the relative prediction
+    accuracy of a forecasting method by calculating the 
+    squared deviation of the prediction and the true
+    value at a given time, and averages these devations
+    over the length of the series.
+    
+    $$ \mathrm{MSE}(\\mathbf{y}_{\\tau}, \\mathbf{\hat{y}}_{\\tau}) = \\frac{1}{H} \\sum^{t+H}_{\\tau=t+1} (y_{\\tau} - \hat{y}_{\\tau})^{2} $$
+    """    
+    def __init__(self):
         super(MSE, self).__init__()
         self.outputsize_multiplier = 1
         self.output_names = ['']
@@ -103,22 +101,21 @@ class MSE(torch.nn.Module):
 
 # %% ../../nbs/losses.pytorch.ipynb 18
 class RMSE(torch.nn.Module):
-    
-    def __init__(self):
-        """ Root Mean Squared Error
+    """ Root Mean Squared Error
 
-        Calculates Root Mean Squared Error between
-        `y` and `y_hat`. RMSE measures the relative prediction
-        accuracy of a forecasting method by calculating the squared deviation
-        of the prediction and the observed value at a given time and
-        averages these devations over the length of the series.
-        Finally the RMSE will be in the same scale
-        as the original time series so its comparison with other
-        series is possible only if they share a common scale. 
-        RMSE has a direct connection to the L2 norm.
-        
-        $$ \mathrm{RMSE}(\\mathbf{y}_{\\tau}, \\mathbf{\hat{y}}_{\\tau}) = \\sqrt{\\frac{1}{H} \\sum^{t+H}_{\\tau=t+1} (y_{\\tau} - \hat{y}_{\\tau})^{2}} $$
-        """
+    Calculates Root Mean Squared Error between
+    `y` and `y_hat`. RMSE measures the relative prediction
+    accuracy of a forecasting method by calculating the squared deviation
+    of the prediction and the observed value at a given time and
+    averages these devations over the length of the series.
+    Finally the RMSE will be in the same scale
+    as the original time series so its comparison with other
+    series is possible only if they share a common scale. 
+    RMSE has a direct connection to the L2 norm.
+    
+    $$ \mathrm{RMSE}(\\mathbf{y}_{\\tau}, \\mathbf{\hat{y}}_{\\tau}) = \\sqrt{\\frac{1}{H} \\sum^{t+H}_{\\tau=t+1} (y_{\\tau} - \hat{y}_{\\tau})^{2}} $$
+    """
+    def __init__(self):
         super(RMSE, self).__init__()
         self.outputsize_multiplier = 1
         self.output_names = ['']
@@ -148,20 +145,19 @@ class RMSE(torch.nn.Module):
 
 # %% ../../nbs/losses.pytorch.ipynb 24
 class MAPE(torch.nn.Module):
-    
-    def __init__(self):
-        """ Mean Absolute Percentage Error
+    """ Mean Absolute Percentage Error
 
-        Calculates Mean Absolute Percentage Error  between
-        `y` and `y_hat`. MAPE measures the relative prediction
-        accuracy of a forecasting method by calculating the percentual deviation
-        of the prediction and the observed value at a given time and
-        averages these devations over the length of the series.
-        The closer to zero an observed value is, the higher penalty MAPE loss
-        assigns to the corresponding error.
-        
-        $$ \mathrm{MAPE}(\\mathbf{y}_{\\tau}, \\mathbf{\hat{y}}_{\\tau}) = \\frac{1}{H} \\sum^{t+H}_{\\tau=t+1} \\frac{|y_{\\tau}-\hat{y}_{\\tau}|}{|y_{\\tau}|} $$
-        """
+    Calculates Mean Absolute Percentage Error  between
+    `y` and `y_hat`. MAPE measures the relative prediction
+    accuracy of a forecasting method by calculating the percentual deviation
+    of the prediction and the observed value at a given time and
+    averages these devations over the length of the series.
+    The closer to zero an observed value is, the higher penalty MAPE loss
+    assigns to the corresponding error.
+    
+    $$ \mathrm{MAPE}(\\mathbf{y}_{\\tau}, \\mathbf{\hat{y}}_{\\tau}) = \\frac{1}{H} \\sum^{t+H}_{\\tau=t+1} \\frac{|y_{\\tau}-\hat{y}_{\\tau}|}{|y_{\\tau}|} $$
+    """    
+    def __init__(self):
         super(MAPE, self).__init__()
         self.outputsize_multiplier = 1
         self.output_names = ['']
@@ -190,24 +186,24 @@ class MAPE(torch.nn.Module):
 
 # %% ../../nbs/losses.pytorch.ipynb 29
 class SMAPE(torch.nn.Module):
+    """ Symmetric Mean Absolute Percentage Error
+
+    Calculates Symmetric Mean Absolute Percentage Error between
+    `y` and `y_hat`. SMAPE measures the relative prediction
+    accuracy of a forecasting method by calculating the relative deviation
+    of the prediction and the observed value scaled by the sum of the
+    absolute values for the prediction and observed value at a
+    given time, then averages these devations over the length
+    of the series. This allows the SMAPE to have bounds between
+    0% and 200% which is desireble compared to normal MAPE that
+    may be undetermined when the target is zero.
+
+    $$ \mathrm{sMAPE}_{2}(\\mathbf{y}_{\\tau}, \\mathbf{\hat{y}}_{\\tau}) = \\frac{1}{H} \\sum^{t+H}_{\\tau=t+1} \\frac{|y_{\\tau}-\hat{y}_{\\tau}|}{|y_{\\tau}|+|\hat{y}_{\\tau}|} $$
+
+    **References:**<br>
+    [Makridakis S., "Accuracy measures: theoretical and practical concerns".](https://www.sciencedirect.com/science/article/pii/0169207093900793)
+    """
     def __init__(self):
-        """ Symmetric Mean Absolute Percentage Error
-        
-        Calculates Symmetric Mean Absolute Percentage Error between
-        `y` and `y_hat`. SMAPE measures the relative prediction
-        accuracy of a forecasting method by calculating the relative deviation
-        of the prediction and the observed value scaled by the sum of the
-        absolute values for the prediction and observed value at a
-        given time, then averages these devations over the length
-        of the series. This allows the SMAPE to have bounds between
-        0% and 200% which is desireble compared to normal MAPE that
-        may be undetermined when the target is zero.
-        
-        $$ \mathrm{sMAPE}_{2}(\\mathbf{y}_{\\tau}, \\mathbf{\hat{y}}_{\\tau}) = \\frac{1}{H} \\sum^{t+H}_{\\tau=t+1} \\frac{|y_{\\tau}-\hat{y}_{\\tau}|}{|y_{\\tau}|+|\hat{y}_{\\tau}|} $$
-        
-        **References:**<br>
-        [Makridakis S., "Accuracy measures: theoretical and practical concerns".](https://www.sciencedirect.com/science/article/pii/0169207093900793)
-        """
         super(SMAPE, self).__init__()
         self.outputsize_multiplier = 1
         self.output_names = ['']
@@ -238,26 +234,25 @@ class SMAPE(torch.nn.Module):
 
 # %% ../../nbs/losses.pytorch.ipynb 34
 class MASE(torch.nn.Module):
+    """ Mean Absolute Scaled Error 
+    Calculates the Mean Absolute Scaled Error between
+    `y` and `y_hat`. MASE measures the relative prediction
+    accuracy of a forecasting method by comparinng the mean absolute errors
+    of the prediction and the observed value against the mean
+    absolute errors of the seasonal naive model.
+    The MASE partially composed the Overall Weighted Average (OWA), 
+    used in the M4 Competition.
+    
+    $$ \mathrm{MASE}(\\mathbf{y}_{\\tau}, \\mathbf{\hat{y}}_{\\tau}, \\mathbf{\hat{y}}^{season}_{\\tau}) = \\frac{1}{H} \sum^{t+H}_{\\tau=t+1} \\frac{|y_{\\tau}-\hat{y}_{\\tau}|}{\mathrm{MAE}(\\mathbf{y}_{\\tau}, \\mathbf{\hat{y}}^{season}_{\\tau})} $$
 
+    **Parameters:**<br>
+    `seasonality`: int. Main frequency of the time series; Hourly 24,  Daily 7, Weekly 52, Monthly 12, Quarterly 4, Yearly 1.
+    
+    **References:**<br>
+    [Rob J. Hyndman, & Koehler, A. B. "Another look at measures of forecast accuracy".](https://www.sciencedirect.com/science/article/pii/S0169207006000239)<br>
+    [Spyros Makridakis, Evangelos Spiliotis, Vassilios Assimakopoulos, "The M4 Competition: 100,000 time series and 61 forecasting methods".](https://www.sciencedirect.com/science/article/pii/S0169207019301128)
+    """
     def __init__(self, seasonality: int):
-        """ Mean Absolute Scaled Error 
-        Calculates the Mean Absolute Scaled Error between
-        `y` and `y_hat`. MASE measures the relative prediction
-        accuracy of a forecasting method by comparinng the mean absolute errors
-        of the prediction and the observed value against the mean
-        absolute errors of the seasonal naive model.
-        The MASE partially composed the Overall Weighted Average (OWA), 
-        used in the M4 Competition.
-        
-        $$ \mathrm{MASE}(\\mathbf{y}_{\\tau}, \\mathbf{\hat{y}}_{\\tau}, \\mathbf{\hat{y}}^{season}_{\\tau}) = \\frac{1}{H} \sum^{t+H}_{\\tau=t+1} \\frac{|y_{\\tau}-\hat{y}_{\\tau}|}{\mathrm{MAE}(\\mathbf{y}_{\\tau}, \\mathbf{\hat{y}}^{season}_{\\tau})} $$
-
-        **Parameters:**<br>
-        `seasonality`: int. Main frequency of the time series; Hourly 24,  Daily 7, Weekly 52, Monthly 12, Quarterly 4, Yearly 1.
-        
-        **References:**<br>
-        [Rob J. Hyndman, & Koehler, A. B. "Another look at measures of forecast accuracy".](https://www.sciencedirect.com/science/article/pii/S0169207006000239)<br>
-        [Spyros Makridakis, Evangelos Spiliotis, Vassilios Assimakopoulos, "The M4 Competition: 100,000 time series and 61 forecasting methods".](https://www.sciencedirect.com/science/article/pii/S0169207019301128)
-        """
         super(MASE, self).__init__()
         self.seasonality = seasonality
         self.outputsize_multiplier = 1
@@ -291,24 +286,23 @@ class MASE(torch.nn.Module):
 
 # %% ../../nbs/losses.pytorch.ipynb 40
 class QuantileLoss(torch.nn.Module):
-    
+    """ Quantile Loss
+
+    Computes the quantile loss between `y` and `y_hat`.
+    QL measures the deviation of a quantile forecast.
+    By weighting the absolute deviation in a non symmetric way, the
+    loss pays more attention to under or over estimation.
+    A common value for q is 0.5 for the deviation from the median (Pinball loss).
+
+    $$ \mathrm{QL}(\\mathbf{y}_{\\tau}, \\mathbf{\hat{y}}^{(q)}_{\\tau}) = \\frac{1}{H} \\sum^{t+H}_{\\tau=t+1} \Big( (1-q)\,( \hat{y}^{(q)}_{\\tau} - y_{\\tau} )_{+} + q\,( y_{\\tau} - \hat{y}^{(q)}_{\\tau} )_{+} \Big) $$
+
+    **Parameters:**<br>
+    `q`: float, between 0 and 1. The slope of the quantile loss, in the context of quantile regression, the q determines the conditional quantile level.<br>
+
+    **References:**<br>
+    [Roger Koenker and Gilbert Bassett, Jr., "Regression Quantiles".](https://www.jstor.org/stable/1913643)
+    """
     def __init__(self, q):
-        """ Quantile Loss
-
-        Computes the quantile loss between `y` and `y_hat`.
-        QL measures the deviation of a quantile forecast.
-        By weighting the absolute deviation in a non symmetric way, the
-        loss pays more attention to under or over estimation.
-        A common value for q is 0.5 for the deviation from the median (Pinball loss).
-
-        $$ \mathrm{QL}(\\mathbf{y}_{\\tau}, \\mathbf{\hat{y}}^{(q)}_{\\tau}) = \\frac{1}{H} \\sum^{t+H}_{\\tau=t+1} \Big( (1-q)\,( \hat{y}^{(q)}_{\\tau} - y_{\\tau} )_{+} + q\,( y_{\\tau} - \hat{y}^{(q)}_{\\tau} )_{+} \Big) $$
-
-        **Parameters:**<br>
-        `q`: float, between 0 and 1. The slope of the quantile loss, in the context of quantile regression, the q determines the conditional quantile level.<br>
-
-        **References:**<br>
-        [Roger Koenker and Gilbert Bassett, Jr., "Regression Quantiles".](https://www.jstor.org/stable/1913643)
-        """
         super(QuantileLoss, self).__init__()
         self.q = q
         self.outputsize_multiplier = 1
@@ -366,34 +360,33 @@ def quantiles_to_outputs(quantiles):
 
 # %% ../../nbs/losses.pytorch.ipynb 46
 class MQLoss(torch.nn.Module):
+    """  Multi-Quantile loss
+
+    Calculates the Multi-Quantile loss (MQL) between `y` and `y_hat`.
+    MQL calculates the average multi-quantile Loss for
+    a given set of quantiles, based on the absolute 
+    difference between predicted quantiles and observed values.
     
+    $$ \mathrm{MQL}(\\mathbf{y}_{\\tau},[\\mathbf{\hat{y}}^{(q_{1})}_{\\tau}, ... ,\hat{y}^{(q_{n})}_{\\tau}]) = \\frac{1}{n} \\sum_{q_{i}} \mathrm{QL}(\\mathbf{y}_{\\tau}, \\mathbf{\hat{y}}^{(q_{i})}_{\\tau}) $$
+    
+    The limit behavior of MQL allows to measure the accuracy 
+    of a full predictive distribution $\mathbf{\hat{F}}_{\\tau}$ with 
+    the continuous ranked probability score (CRPS). This can be achieved 
+    through a numerical integration technique, that discretizes the quantiles 
+    and treats the CRPS integral with a left Riemann approximation, averaging over 
+    uniformly distanced quantiles.    
+    
+    $$ \mathrm{CRPS}(y_{\\tau}, \mathbf{\hat{F}}_{\\tau}) = \int^{1}_{0} \mathrm{QL}(y_{\\tau}, \hat{y}^{(q)}_{\\tau}) dq $$
+
+    **Parameters:**<br>
+    `level`: int list [0,100]. Probability levels for prediction intervals (Defaults median).
+    `quantiles`: float list [0., 1.]. Alternative to level, quantiles to estimate from y distribution.
+
+    **References:**<br>
+    [Roger Koenker and Gilbert Bassett, Jr., "Regression Quantiles".](https://www.jstor.org/stable/1913643)<br>
+    [James E. Matheson and Robert L. Winkler, "Scoring Rules for Continuous Probability Distributions".](https://www.jstor.org/stable/2629907)
+    """
     def __init__(self, level=[80, 90], quantiles=None):
-        """  Multi-Quantile loss
-    
-        Calculates the Multi-Quantile loss (MQL) between `y` and `y_hat`.
-        MQL calculates the average multi-quantile Loss for
-        a given set of quantiles, based on the absolute 
-        difference between predicted quantiles and observed values.
-        
-        $$ \mathrm{MQL}(\\mathbf{y}_{\\tau},[\\mathbf{\hat{y}}^{(q_{1})}_{\\tau}, ... ,\hat{y}^{(q_{n})}_{\\tau}]) = \\frac{1}{n} \\sum_{q_{i}} \mathrm{QL}(\\mathbf{y}_{\\tau}, \\mathbf{\hat{y}}^{(q_{i})}_{\\tau}) $$
-        
-        The limit behavior of MQL allows to measure the accuracy 
-        of a full predictive distribution $\mathbf{\hat{F}}_{\\tau}$ with 
-        the continuous ranked probability score (CRPS). This can be achieved 
-        through a numerical integration technique, that discretizes the quantiles 
-        and treats the CRPS integral with a left Riemann approximation, averaging over 
-        uniformly distanced quantiles.    
-        
-        $$ \mathrm{CRPS}(y_{\\tau}, \mathbf{\hat{F}}_{\\tau}) = \int^{1}_{0} \mathrm{QL}(y_{\\tau}, \hat{y}^{(q)}_{\\tau}) dq $$
-
-        **Parameters:**<br>
-        `level`: int list [0,100]. Probability levels for prediction intervals (Defaults median).
-        `quantiles`: float list [0., 1.]. Alternative to level, quantiles to estimate from y distribution.
-
-        **References:**<br>
-        [Roger Koenker and Gilbert Bassett, Jr., "Regression Quantiles".](https://www.jstor.org/stable/1913643)<br>
-        [James E. Matheson and Robert L. Winkler, "Scoring Rules for Continuous Probability Distributions".](https://www.jstor.org/stable/2629907)
-        """
         super(MQLoss, self).__init__()
         # Transform level to MQLoss parameters
         if level:
@@ -446,25 +439,24 @@ class MQLoss(torch.nn.Module):
 
 # %% ../../nbs/losses.pytorch.ipynb 51
 class wMQLoss(torch.nn.Module):
+    """ Weighted Multi-Quantile loss
     
-    def __init__(self, level=[80, 90], quantiles=None):
-        """ Weighted Multi-Quantile loss
+    Calculates the Weighted Multi-Quantile loss (WMQL) between `y` and `y_hat`.
+    WMQL calculates the weighted average multi-quantile Loss for
+    a given set of quantiles, based on the absolute 
+    difference between predicted quantiles and observed values.  
         
-        Calculates the Weighted Multi-Quantile loss (WMQL) between `y` and `y_hat`.
-        WMQL calculates the weighted average multi-quantile Loss for
-        a given set of quantiles, based on the absolute 
-        difference between predicted quantiles and observed values.  
-            
-        $$ \mathrm{wMQL}(\\mathbf{y}_{\\tau},[\\mathbf{\hat{y}}^{(q_{1})}_{\\tau}, ... ,\hat{y}^{(q_{n})}_{\\tau}]) = \\frac{1}{n} \\sum_{q_{i}} \\frac{\mathrm{QL}(\\mathbf{y}_{\\tau}, \\mathbf{\hat{y}}^{(q_{i})}_{\\tau})}{\\sum^{t+H}_{\\tau=t+1} |y_{\\tau}|} $$
-        
-        **Parameters:**<br>
-        `level`: int list [0,100]. Probability levels for prediction intervals (Defaults median).
-        `quantiles`: float list [0., 1.]. Alternative to level, quantiles to estimate from y distribution.
+    $$ \mathrm{wMQL}(\\mathbf{y}_{\\tau},[\\mathbf{\hat{y}}^{(q_{1})}_{\\tau}, ... ,\hat{y}^{(q_{n})}_{\\tau}]) = \\frac{1}{n} \\sum_{q_{i}} \\frac{\mathrm{QL}(\\mathbf{y}_{\\tau}, \\mathbf{\hat{y}}^{(q_{i})}_{\\tau})}{\\sum^{t+H}_{\\tau=t+1} |y_{\\tau}|} $$
+    
+    **Parameters:**<br>
+    `level`: int list [0,100]. Probability levels for prediction intervals (Defaults median).
+    `quantiles`: float list [0., 1.]. Alternative to level, quantiles to estimate from y distribution.
 
-        **References:**<br>
-        [Roger Koenker and Gilbert Bassett, Jr., "Regression Quantiles".](https://www.jstor.org/stable/1913643)<br>
-        [James E. Matheson and Robert L. Winkler, "Scoring Rules for Continuous Probability Distributions".](https://www.jstor.org/stable/2629907)
-        """
+    **References:**<br>
+    [Roger Koenker and Gilbert Bassett, Jr., "Regression Quantiles".](https://www.jstor.org/stable/1913643)<br>
+    [James E. Matheson and Robert L. Winkler, "Scoring Rules for Continuous Probability Distributions".](https://www.jstor.org/stable/2629907)
+    """
+    def __init__(self, level=[80, 90], quantiles=None):
         super(wMQLoss, self).__init__()
         # Transform level to MQLoss parameters
         if level:
@@ -514,23 +506,22 @@ class wMQLoss(torch.nn.Module):
 
 # %% ../../nbs/losses.pytorch.ipynb 56
 class PMM(torch.nn.Module):
+    """ Poisson Mixture Mesh
 
+    This Poisson Mixture statistical model assumes independence across groups of 
+    data $\mathcal{G}=\{[g_{i}]\}$, and estimates relationships within the group.
+
+    $$ \mathrm{P}\\left(\mathbf{y}_{[b][t+1:t+H]}\\right) = 
+    \prod_{ [g_{i}] \in \mathcal{G}} \mathrm{P} \\left(\mathbf{y}_{[g_{i}][\\tau]} \\right) =
+    \prod_{\\beta\in[g_{i}]} 
+    \\left(\sum_{k=1}^{K} w_k \prod_{(\\beta,\\tau) \in [g_i][t+1:t+H]} \mathrm{Poisson}(y_{\\beta,\\tau}, \hat{\\lambda}_{\\beta,\\tau,k}) \\right)$$
+
+    **References:**<br>
+    [Kin G. Olivares, O. Nganba Meetei, Ruijun Ma, Rohan Reddy, Mengfei Cao, Lee Dicker. 
+    Probabilistic Hierarchical Forecasting with Deep Poisson Mixtures. Submitted to the International 
+    Journal Forecasting, Working paper available at arxiv.](https://arxiv.org/pdf/2110.13179.pdf)
+    """
     def __init__(self, level=[80, 90], quantiles=None):
-        """ Poisson Mixture Mesh
-
-        This Poisson Mixture statistical model assumes independence across groups of 
-        data $\mathcal{G}=\{[g_{i}]\}$, and estimates relationships within the group.
-
-        $$ P\\left(\mathbf{y}_{[b][t+1:t+H]}\\right) = 
-        \prod_{ [g_{i}] \in \mathcal{G}} P \\left(\mathbf{y}_{[g_{i}][\\tau]} \\right) =
-        \prod_{\\beta\in[g_{i}]} 
-        \\left(\sum_{k=1}^{K} w_k \prod_{(\\beta,\\tau) \in [g_i][t+1:t+H]} \mathrm{Poisson}(y_{\\beta,\\tau}, \hat{\\lambda}_{\\beta,\\tau,k}) \\right)$$
-
-        **References:**<br>
-        [Kin G. Olivares, O. Nganba Meetei, Ruijun Ma, Rohan Reddy, Mengfei Cao, Lee Dicker. 
-        Probabilistic Hierarchical Forecasting with Deep Poisson Mixtures. Submitted to the International 
-        Journal Forecasting, Working paper available at arxiv.](https://arxiv.org/pdf/2110.13179.pdf)
-        """
         super(PMM, self).__init__()
         # Transform level to MQLoss parameters
         if level:
@@ -622,26 +613,25 @@ class PMM(torch.nn.Module):
         return self.neglog_likelihood(y=y, weights=weights, lambdas=lambdas, mask=mask)
 
 
-# %% ../../nbs/losses.pytorch.ipynb 60
+# %% ../../nbs/losses.pytorch.ipynb 63
 class GMM(torch.nn.Module):
+    """ Gaussian Mixture Mesh
 
+    This Gaussian Mixture statistical model assumes independence across groups of 
+    data $\mathcal{G}=\{[g_{i}]\}$, and estimates relationships within the group.
+
+    $$ \mathrm{P}\\left(\mathbf{y}_{[b][t+1:t+H]}\\right) = 
+    \prod_{ [g_{i}] \in \mathcal{G}} \mathrm{P}\left(\mathbf{y}_{[g_{i}][\\tau]}\\right)=
+    \prod_{\\beta\in[g_{i}]}
+    \\left(\sum_{k=1}^{K} w_k \prod_{(\\beta,\\tau) \in [g_i][t+1:t+H]} 
+    \mathrm{Gaussian}(y_{\\beta,\\tau}, \hat{\mu}_{\\beta,\\tau,k}, \sigma_{\\beta,\\tau,k})\\right)$$
+
+    **References:**<br>
+    [Kin G. Olivares, O. Nganba Meetei, Ruijun Ma, Rohan Reddy, Mengfei Cao, Lee Dicker. 
+    Probabilistic Hierarchical Forecasting with Deep Poisson Mixtures. Submitted to the International 
+    Journal Forecasting, Working paper available at arxiv.](https://arxiv.org/pdf/2110.13179.pdf)
+    """
     def __init__(self, level=[80, 90], quantiles=None):
-        """ Gaussian Mixture Mesh
-
-        This Gaussian Mixture statistical model assumes independence across groups of 
-        data $\mathcal{G}=\{[g_{i}]\}$, and estimates relationships within the group.
-
-        $$ P\\left(\mathbf{y}_{[b][t+1:t+H]}\\right) = 
-        \prod_{ [g_{i}] \in \mathcal{G}} P\left(\mathbf{y}_{[g_{i}][\\tau]}\\right)=
-        \prod_{\\beta\in[g_{i}]}
-        \\left(\sum_{k=1}^{K} w_k \prod_{(\\beta,\\tau) \in [g_i][t+1:t+H]} 
-        \mathrm{Gaussian}(y_{\\beta,\\tau}, \hat{\mu}_{\\beta,\\tau,k}, \sigma_{\\beta,\\tau,k})\\right)$$
-
-        **References:**<br>
-        [Kin G. Olivares, O. Nganba Meetei, Ruijun Ma, Rohan Reddy, Mengfei Cao, Lee Dicker. 
-        Probabilistic Hierarchical Forecasting with Deep Poisson Mixtures. Submitted to the International 
-        Journal Forecasting, Working paper available at arxiv.](https://arxiv.org/pdf/2110.13179.pdf)
-        """
         super(GMM, self).__init__()
         # Transform level to MQLoss parameters
         if level:


### PR DESCRIPTION
The patch of the pytorch losses to inherit the `nn.module` class broke the previous documentation, as the `__init__`'s documentation default was using the documentation inherited from `nn.module.__init__`.

Changed all losses to have their own `__init__` documentation.