### PR TITLE
[FIX] Add correct link to hierarchicalforecast

### DIFF
--- a/nbs/_quarto.yml
+++ b/nbs/_quarto.yml
@@ -32,7 +32,7 @@ website:
           - text: "StatsForecast ⚡️"
             href: https://github.com/nixtla/statsforecast
           - text: "HierarchicalForecast 👑"
-            href: "https://github.com/nixtla/hierachicalforecast"
+            href: "https://github.com/nixtla/hierarchicalforecast"
           
       - text: "Help"
         menu:


### PR DESCRIPTION
There was a typo in the hierarchicalforecast url. 