### PR TITLE
Fix: Fixed torch.concat in base_recurrent return params

### DIFF
--- a/nbs/common.base_recurrent.ipynb
+++ b/nbs/common.base_recurrent.ipynb
@@ -449,8 +449,8 @@
     "\n",
     "            if self.loss.return_params:\n",
     "                distr_args = torch.stack(distr_args, dim=-1)\n",
-    "                distr_args = torch.reshape(distr_args, (len(windows[\"temporal\"]), self.h, -1))\n",
-    "                y_hat = torch.concat((y_hat, distr_args), axis=2)\n",
+    "                distr_args = torch.reshape(distr_args, (B, T, H, -1))\n",
+    "                y_hat = torch.concat((y_hat, distr_args), axis=3)\n",
     "        else:\n",
     "            y_hat, _, _ = self._inv_normalization(y_hat=output,\n",
     "                                            temporal_cols=batch['temporal_cols'])\n",
@@ -598,7 +598,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   }

--- a/nbs/models.tcn.ipynb
+++ b/nbs/models.tcn.ipynb
@@ -321,7 +321,7 @@
     "    models=[TCN(h=12,\n",
     "                input_size=-1,\n",
     "                #loss=DistributionLoss(distribution='Normal', level=[80, 90]),\n",
-    "                loss=GMM(n_components=2, level=[80,90]),\n",
+    "                loss=GMM(n_components=7, return_params=True, level=[80,90]),\n",
     "                learning_rate=5e-4,\n",
     "                kernel_size=2,\n",
     "                dilations=[1,2,4,8,16],\n",
@@ -370,7 +370,7 @@
   "kernelspec": {
    "display_name": "neuralforecast",
    "language": "python",
-   "name": "python3"
+   "name": "neuralforecast"
   }
  },
  "nbformat": 4,

--- a/neuralforecast/common/_base_recurrent.py
+++ b/neuralforecast/common/_base_recurrent.py
@@ -478,10 +478,8 @@ class BaseRecurrent(pl.LightningModule):
 
             if self.loss.return_params:
                 distr_args = torch.stack(distr_args, dim=-1)
-                distr_args = torch.reshape(
-                    distr_args, (len(windows["temporal"]), self.h, -1)
-                )
-                y_hat = torch.concat((y_hat, distr_args), axis=2)
+                distr_args = torch.reshape(distr_args, (B, T, H, -1))
+                y_hat = torch.concat((y_hat, distr_args), axis=3)
         else:
             y_hat, _, _ = self._inv_normalization(
                 y_hat=output, temporal_cols=batch["temporal_cols"]


### PR DESCRIPTION
base_recurrent had incorrect reshaping in the "if self.loss.return_params" section, which would cause models to fail when using distribution loss with return_params=true. An example of the error can be seen below:
![image](https://user-images.githubusercontent.com/60141418/216683368-81332785-ac7f-4416-beec-4684f0c04537.png)
This pull request fixes the torch.concat error with a proper reshaping. Tested the fix with TCN.