### PR TITLE
Fix: Fixed shape of "output" in valid_loss evaluation for base_recurrent

### DIFF
--- a/nbs/common.base_recurrent.ipynb
+++ b/nbs/common.base_recurrent.ipynb
@@ -399,13 +399,13 @@
     "            y_loc = y_loc.repeat_interleave(repeats=T, dim=0).squeeze(-1)\n",
     "            y_scale = y_scale.repeat_interleave(repeats=T, dim=0).squeeze(-1)\n",
     "            distr_args = self.loss.scale_decouple(output=output, loc=y_loc, scale=y_scale)\n",
+    "            _, output = self.loss.sample(distr_args=distr_args, num_samples=500)\n",
     "\n",
     "        # Validation Loss evaluation\n",
     "        if self.valid_loss.is_distribution_output:\n",
     "            valid_loss = self.valid_loss(y=outsample_y, distr_args=distr_args, mask=outsample_mask)\n",
     "        else:\n",
-    "            y_hat = output[:, -val_windows:-1, :]\n",
-    "            valid_loss = self.valid_loss(y=outsample_y, y_hat=y_hat, mask=outsample_mask)\n",
+    "            valid_loss = self.valid_loss(y=outsample_y, y_hat=output, mask=outsample_mask)\n",
     "\n",
     "        self.log('valid_loss', valid_loss, batch_size=self.batch_size, prog_bar=True, on_epoch=True)\n",
     "        return valid_loss\n",
@@ -598,9 +598,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "neuralforecast",
    "language": "python",
-   "name": "python3"
+   "name": "neuralforecast"
   }
  },
  "nbformat": 4,

--- a/neuralforecast/common/_base_recurrent.py
+++ b/neuralforecast/common/_base_recurrent.py
@@ -406,6 +406,7 @@ class BaseRecurrent(pl.LightningModule):
             distr_args = self.loss.scale_decouple(
                 output=output, loc=y_loc, scale=y_scale
             )
+            _, output = self.loss.sample(distr_args=distr_args, num_samples=500)
 
         # Validation Loss evaluation
         if self.valid_loss.is_distribution_output:
@@ -413,9 +414,8 @@ class BaseRecurrent(pl.LightningModule):
                 y=outsample_y, distr_args=distr_args, mask=outsample_mask
             )
         else:
-            y_hat = output[:, -val_windows:-1, :]
             valid_loss = self.valid_loss(
-                y=outsample_y, y_hat=y_hat, mask=outsample_mask
+                y=outsample_y, y_hat=output, mask=outsample_mask
             )
 
         self.log(


### PR DESCRIPTION
When running base_recurrent models with valid_loss, the shape of "output" is incorrect in the validation_step:
![image](https://user-images.githubusercontent.com/60141418/217667455-338ee88b-2f19-4432-baea-9d5c054fed69.png)
I changed it by adding a line earlier:
`_, output = self.loss.sample(distr_args=distr_args, num_samples=500)`
which updates "output" (same way base_windows does it).

Tested with TCN, valid_loss = sCRPS, loss=GMM()