### PR TITLE
Fix: Fixed sCRPS in losses.pytorch notebook

### DIFF
--- a/nbs/losses.pytorch.ipynb
+++ b/nbs/losses.pytorch.ipynb
@@ -2721,6 +2721,18 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/nbs/losses.pytorch.ipynb
+++ b/nbs/losses.pytorch.ipynb
@@ -1187,7 +1187,7 @@
     "        `scrps`: tensor (single value).\n",
     "        \"\"\"\n",
     "        mql = self.mql(y=y, y_hat=y_hat, mask=mask)\n",
-    "        norm = torch.sum(y)\n",
+    "        norm = torch.sum(torch.abs(y))\n",
     "        unmean = torch.sum(mask)\n",
     "        scrps = 2 * mql * unmean / (norm + 1e-5)\n",
     "        return scrps"
@@ -2408,7 +2408,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "694a2afe",
    "metadata": {},
@@ -2719,7 +2718,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "python3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   }

--- a/neuralforecast/losses/pytorch.py
+++ b/neuralforecast/losses/pytorch.py
@@ -692,7 +692,7 @@ class sCRPS(torch.nn.Module):
         `scrps`: tensor (single value).
         """
         mql = self.mql(y=y, y_hat=y_hat, mask=mask)
-        norm = torch.sum(y)
+        norm = torch.sum(torch.abs(y))
         unmean = torch.sum(mask)
         scrps = 2 * mql * unmean / (norm + 1e-5)
         return scrps


### PR DESCRIPTION
In the sCRPS specification, the bottom norm should be a summation of the absolute value of the y's. Currently, the y's are not encapsulated by absolute value, so I added it.