### PR TITLE
[FIX]: AutoHINT to update HINT test_size

### DIFF
--- a/nbs/models.ipynb
+++ b/nbs/models.ipynb
@@ -97,7 +97,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "7ae65ca7",
    "metadata": {},
@@ -1629,7 +1628,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "e6fd22c7",
    "metadata": {},
@@ -1798,6 +1796,7 @@
     "        base_model = cls_model(**config)\n",
     "        model = HINT(h=base_model.h, model=base_model, \n",
     "                     S=self.S, reconciliation=reconciliation)\n",
+    "        model.test_size = test_size\n",
     "        model.fit(\n",
     "            dataset,\n",
     "            val_size=val_size, \n",

--- a/neuralforecast/auto.py
+++ b/neuralforecast/auto.py
@@ -957,5 +957,6 @@ class AutoHINT(BaseAuto):
         model = HINT(
             h=base_model.h, model=base_model, S=self.S, reconciliation=reconciliation
         )
+        model.test_size = test_size
         model.fit(dataset, val_size=val_size, test_size=test_size)
         return model


### PR DESCRIPTION
When running AutoHINT as a model inside the NeuralForecast class and trying to call .predict(), we get the following error:
![image](https://github.com/Nixtla/neuralforecast/assets/60141418/bd66311a-a2eb-446f-bf07-d95966b97876)
I updated the AutoHINT class with a one line change to set the test_size for the HINT class to avoid this error.