### PR TITLE
[BUG] Fixing inference_input_size_multiplier bug

### DIFF
--- a/nbs/models.ipynb
+++ b/nbs/models.ipynb
@@ -97,6 +97,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "7ae65ca7",
    "metadata": {},
@@ -107,6 +108,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "5b8183a9",
    "metadata": {},
@@ -115,6 +117,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "858e6a1b",
    "metadata": {},
@@ -167,10 +170,10 @@
     "        if config is None:\n",
     "            config = self.default_config.copy()        \n",
     "            config['input_size'] = tune.choice([h*x \\\n",
-    "                         for x in self.default_config[\"input_size_multiplier\"]])\n",
+    "                         for x in self.default_config['input_size_multiplier']])\n",
     "            config['inference_input_size'] = tune.choice([h*x \\\n",
-    "                         for x in self.default_config[\"inference_input_size_multiplier\"]])\n",
-    "            del config[\"input_size_multiplier\"]\n",
+    "                         for x in self.default_config['inference_input_size_multiplier']])\n",
+    "            del config['input_size_multiplier'], config['inference_input_size_multiplier']\n",
     "\n",
     "        super(AutoRNN, self).__init__(\n",
     "              cls_model=RNN, \n",
@@ -289,10 +292,10 @@
     "        if config is None:\n",
     "            config = self.default_config.copy()        \n",
     "            config['input_size'] = tune.choice([h*x \\\n",
-    "                         for x in self.default_config[\"input_size_multiplier\"]])\n",
+    "                         for x in self.default_config['input_size_multiplier']])\n",
     "            config['inference_input_size'] = tune.choice([h*x \\\n",
-    "                         for x in self.default_config[\"inference_input_size_multiplier\"]])\n",
-    "            del config[\"input_size_multiplier\"]\n",
+    "                         for x in self.default_config['inference_input_size_multiplier']])\n",
+    "            del config['input_size_multiplier'], config['inference_input_size_multiplier']\n",
     "\n",
     "        super(AutoLSTM, self).__init__(\n",
     "              cls_model=LSTM,\n",
@@ -330,6 +333,23 @@
     "# Use your own config or AutoLSTM.default_config\n",
     "config = dict(max_steps=2, val_check_steps=1, input_size=-1, encoder_hidden_size=8)\n",
     "model = AutoLSTM(h=12, config=config, num_samples=1, cpus=1)\n",
+    "\n",
+    "# Fit and predict\n",
+    "model.fit(dataset=dataset)\n",
+    "y_hat = model.predict(dataset=dataset)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2320c168",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %%capture\n",
+    "# Use your own config or AutoLSTM.default_config\n",
+    "config = dict(max_steps=2, val_check_steps=1, input_size=-1, encoder_hidden_size=8)\n",
+    "model = AutoLSTM(h=12, num_samples=1, cpus=1)\n",
     "\n",
     "# Fit and predict\n",
     "model.fit(dataset=dataset)\n",
@@ -392,10 +412,10 @@
     "        if config is None:\n",
     "            config = self.default_config.copy()        \n",
     "            config['input_size'] = tune.choice([h*x \\\n",
-    "                         for x in self.default_config[\"input_size_multiplier\"]])\n",
+    "                         for x in self.default_config['input_size_multiplier']])\n",
     "            config['inference_input_size'] = tune.choice([h*x \\\n",
-    "                         for x in self.default_config[\"inference_input_size_multiplier\"]])\n",
-    "            del config[\"input_size_multiplier\"]\n",
+    "                         for x in self.default_config['inference_input_size_multiplier']])\n",
+    "            del config['input_size_multiplier'], config['inference_input_size_multiplier']\n",
     "\n",
     "        super(AutoGRU, self).__init__(\n",
     "              cls_model=GRU,\n",
@@ -495,10 +515,10 @@
     "        if config is None:\n",
     "            config = self.default_config.copy()        \n",
     "            config['input_size'] = tune.choice([h*x \\\n",
-    "                         for x in self.default_config[\"input_size_multiplier\"]])\n",
+    "                         for x in self.default_config['input_size_multiplier']])\n",
     "            config['inference_input_size'] = tune.choice([h*x \\\n",
-    "                         for x in self.default_config[\"inference_input_size_multiplier\"]])\n",
-    "            del config[\"input_size_multiplier\"]\n",
+    "                         for x in self.default_config['inference_input_size_multiplier']])\n",
+    "            del config['input_size_multiplier'], config['inference_input_size_multiplier']\n",
     "\n",
     "        super(AutoTCN, self).__init__(\n",
     "              cls_model=TCN,\n",
@@ -600,10 +620,10 @@
     "        if config is None:\n",
     "            config = self.default_config.copy()        \n",
     "            config['input_size'] = tune.choice([h*x \\\n",
-    "                         for x in self.default_config[\"input_size_multiplier\"]])\n",
+    "                         for x in self.default_config['input_size_multiplier']])\n",
     "            config['inference_input_size'] = tune.choice([h*x \\\n",
-    "                         for x in self.default_config[\"inference_input_size_multiplier\"]])\n",
-    "            del config[\"input_size_multiplier\"]\n",
+    "                         for x in self.default_config['inference_input_size_multiplier']])\n",
+    "            del config['input_size_multiplier'], config['inference_input_size_multiplier']\n",
     "\n",
     "        super(AutoDilatedRNN, self).__init__(\n",
     "              cls_model=DilatedRNN,\n",
@@ -663,6 +683,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "7feff99a",
    "metadata": {},
@@ -1093,6 +1114,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "fd705a56",
    "metadata": {},
@@ -1628,6 +1650,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "e6fd22c7",
    "metadata": {},
@@ -1913,6 +1936,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "69d588d9",
    "metadata": {},

--- a/neuralforecast/auto.py
+++ b/neuralforecast/auto.py
@@ -80,7 +80,10 @@ class AutoRNN(BaseAuto):
             config["inference_input_size"] = tune.choice(
                 [h * x for x in self.default_config["inference_input_size_multiplier"]]
             )
-            del config["input_size_multiplier"]
+            del (
+                config["input_size_multiplier"],
+                config["inference_input_size_multiplier"],
+            )
 
         super(AutoRNN, self).__init__(
             cls_model=RNN,
@@ -135,7 +138,10 @@ class AutoLSTM(BaseAuto):
             config["inference_input_size"] = tune.choice(
                 [h * x for x in self.default_config["inference_input_size_multiplier"]]
             )
-            del config["input_size_multiplier"]
+            del (
+                config["input_size_multiplier"],
+                config["inference_input_size_multiplier"],
+            )
 
         super(AutoLSTM, self).__init__(
             cls_model=LSTM,
@@ -151,7 +157,7 @@ class AutoLSTM(BaseAuto):
             verbose=verbose,
         )
 
-# %% ../nbs/models.ipynb 17
+# %% ../nbs/models.ipynb 18
 class AutoGRU(BaseAuto):
     default_config = {
         "input_size_multiplier": [-1, 4, 16, 64],
@@ -191,7 +197,10 @@ class AutoGRU(BaseAuto):
             config["inference_input_size"] = tune.choice(
                 [h * x for x in self.default_config["inference_input_size_multiplier"]]
             )
-            del config["input_size_multiplier"]
+            del (
+                config["input_size_multiplier"],
+                config["inference_input_size_multiplier"],
+            )
 
         super(AutoGRU, self).__init__(
             cls_model=GRU,
@@ -208,7 +217,7 @@ class AutoGRU(BaseAuto):
             alias=alias,
         )
 
-# %% ../nbs/models.ipynb 21
+# %% ../nbs/models.ipynb 22
 class AutoTCN(BaseAuto):
     default_config = {
         "input_size_multiplier": [-1, 4, 16, 64],
@@ -247,7 +256,10 @@ class AutoTCN(BaseAuto):
             config["inference_input_size"] = tune.choice(
                 [h * x for x in self.default_config["inference_input_size_multiplier"]]
             )
-            del config["input_size_multiplier"]
+            del (
+                config["input_size_multiplier"],
+                config["inference_input_size_multiplier"],
+            )
 
         super(AutoTCN, self).__init__(
             cls_model=TCN,
@@ -264,7 +276,7 @@ class AutoTCN(BaseAuto):
             alias=alias,
         )
 
-# %% ../nbs/models.ipynb 25
+# %% ../nbs/models.ipynb 26
 class AutoDilatedRNN(BaseAuto):
     default_config = {
         "input_size_multiplier": [-1, 4, 16, 64],
@@ -305,7 +317,10 @@ class AutoDilatedRNN(BaseAuto):
             config["inference_input_size"] = tune.choice(
                 [h * x for x in self.default_config["inference_input_size_multiplier"]]
             )
-            del config["input_size_multiplier"]
+            del (
+                config["input_size_multiplier"],
+                config["inference_input_size_multiplier"],
+            )
 
         super(AutoDilatedRNN, self).__init__(
             cls_model=DilatedRNN,
@@ -322,7 +337,7 @@ class AutoDilatedRNN(BaseAuto):
             alias=alias,
         )
 
-# %% ../nbs/models.ipynb 30
+# %% ../nbs/models.ipynb 31
 class AutoMLP(BaseAuto):
     default_config = {
         "input_size_multiplier": [1, 2, 3, 4, 5],
@@ -379,7 +394,7 @@ class AutoMLP(BaseAuto):
             alias=alias,
         )
 
-# %% ../nbs/models.ipynb 34
+# %% ../nbs/models.ipynb 35
 class AutoNBEATS(BaseAuto):
     default_config = {
         "input_size_multiplier": [1, 2, 3, 4, 5],
@@ -434,7 +449,7 @@ class AutoNBEATS(BaseAuto):
             alias=alias,
         )
 
-# %% ../nbs/models.ipynb 38
+# %% ../nbs/models.ipynb 39
 class AutoNBEATSx(BaseAuto):
     default_config = {
         "input_size_multiplier": [1, 2, 3, 4, 5],
@@ -489,7 +504,7 @@ class AutoNBEATSx(BaseAuto):
             alias=alias,
         )
 
-# %% ../nbs/models.ipynb 42
+# %% ../nbs/models.ipynb 43
 class AutoNHITS(BaseAuto):
     default_config = {
         "input_size_multiplier": [1, 2, 3, 4, 5],
@@ -561,7 +576,7 @@ class AutoNHITS(BaseAuto):
             alias=alias,
         )
 
-# %% ../nbs/models.ipynb 47
+# %% ../nbs/models.ipynb 48
 class AutoTFT(BaseAuto):
     default_config = {
         "input_size_multiplier": [1, 2, 3, 4, 5],
@@ -618,7 +633,7 @@ class AutoTFT(BaseAuto):
             alias=alias,
         )
 
-# %% ../nbs/models.ipynb 51
+# %% ../nbs/models.ipynb 52
 class AutoVanillaTransformer(BaseAuto):
     default_config = {
         "input_size_multiplier": [1, 2, 3, 4, 5],
@@ -675,7 +690,7 @@ class AutoVanillaTransformer(BaseAuto):
             alias=alias,
         )
 
-# %% ../nbs/models.ipynb 55
+# %% ../nbs/models.ipynb 56
 class AutoInformer(BaseAuto):
     default_config = {
         "input_size_multiplier": [1, 2, 3, 4, 5],
@@ -732,7 +747,7 @@ class AutoInformer(BaseAuto):
             alias=alias,
         )
 
-# %% ../nbs/models.ipynb 59
+# %% ../nbs/models.ipynb 60
 class AutoAutoformer(BaseAuto):
     default_config = {
         "input_size_multiplier": [1, 2, 3, 4, 5],
@@ -789,7 +804,7 @@ class AutoAutoformer(BaseAuto):
             alias=alias,
         )
 
-# %% ../nbs/models.ipynb 63
+# %% ../nbs/models.ipynb 64
 class AutoPatchTST(BaseAuto):
     default_config = {
         "input_size_multiplier": [1, 2, 3],
@@ -848,7 +863,7 @@ class AutoPatchTST(BaseAuto):
             alias=alias,
         )
 
-# %% ../nbs/models.ipynb 68
+# %% ../nbs/models.ipynb 69
 class AutoStemGNN(BaseAuto):
     default_config = {
         "input_size_multiplier": [1, 2, 3, 4],
@@ -909,7 +924,7 @@ class AutoStemGNN(BaseAuto):
             alias=alias,
         )
 
-# %% ../nbs/models.ipynb 72
+# %% ../nbs/models.ipynb 73
 class AutoHINT(BaseAuto):
     def __init__(
         self,


### PR DESCRIPTION
From the recent addition of inference_input_size parameter in https://github.com/Nixtla/neuralforecast/pull/536, the AutoLSTM, AutoGRU, AutoTCN methods initialization, did not have the appropriate deletion of the default config['inference_input_size_multiplier'] that resulted in a failed instantiation.