### PR TITLE
[FEAT] Add stats, ml, neural forecasting methods tutorial

### DIFF
--- a/nbs/sidebar.yml
+++ b/nbs/sidebar.yml
@@ -27,6 +27,7 @@ website:
         - examples/Temporal_Classifiers.ipynb
         - examples/Robust_Regression.ipynb
         - examples/Signal_Decomposition.ipynb
+        - examples/StatsMlNeuralMethods.ipynb
       - examples/models_intro.qmd
       - section: API Reference
         contents:


### PR DESCRIPTION
This PR adds a tutorial on how to use statsforecast, mlforecast, and neuralforecast in the same pipeline. 