### PR TITLE
[FIX] NBEATSx-i horizon=1 protection, and added NBEATSx to MODEL_FILENAME_DICT

### DIFF
--- a/nbs/core.ipynb
+++ b/nbs/core.ipynb
@@ -40,6 +40,9 @@
    "outputs": [],
    "source": [
     "#| hide\n",
+    "import os\n",
+    "os.environ[\"PYTORCH_ENABLE_MPS_FALLBACK\"] = \"1\"\n",
+    "\n",
     "import shutil\n",
     "from fastcore.test import test_eq, test_fail\n",
     "from nbdev.showdoc import show_doc\n",
@@ -233,7 +236,7 @@
     "                       'stemgnn': StemGNN,\n",
     "                       'autogru': GRU, 'autolstm': LSTM, 'autornn': RNN,\n",
     "                       'autotcn': TCN, 'autodilatedrnn': DilatedRNN,\n",
-    "                       'automlp': MLP, 'autonbeats': NBEATS, 'autonhits': NHITS,\n",
+    "                       'automlp': MLP, 'autonbeats': NBEATS, 'autonbeatsx': NBEATSx, 'autonhits': NHITS,\n",
     "                       'autotft': TFT,\n",
     "                       'autovanillatransformer': VanillaTransformer,'autoinformer': Informer, 'autoautoformer': Autoformer, 'autopatchtst': PatchTST,\n",
     "                       'autofedformer': FEDformer,\n",

--- a/nbs/examples/models_intro.qmd
+++ b/nbs/examples/models_intro.qmd
@@ -34,7 +34,9 @@ NeuralForecast is a highly modular framework capable of augmenting a wide variet
 |[`PMM`](../losses.pytorch.html#poisson-mixture-mesh-pmm) /[`GMM`](../losses.pytorch.html#gaussian-mixture-mesh-gmm)  |       |
 : {tbl-colwidths="[25,25]"}
 
-## MLP-Based Model Family
+## Available Models
+
+### MLP-Based
 The MLP-based family operates like a classic autoencoder. Its initial layers encode raw autoregressive window into a representation, and the decoder produces the desired output based on the horizon, probability output, or point objective. Recent architectures include modifications like residual learning techniques and task-specific changes.
 
 |Model                                     | Point Forecast | Probabilistic Forecast | Insample fitted values | Probabilistic fitted values  |
@@ -45,7 +47,7 @@ The MLP-based family operates like a classic autoencoder. Its initial layers enc
 |[`NHITS`](../models.nhits.html)           |✅              |✅                      |✅                      |✅                            |
 : {tbl-colwidths="[25,25]"}
 
-## RNN-Based Model Family
+### RNN-Based Model Family
 The RNN-based family attempts to leverage the data's temporal structure while reducing MLPs over parametrization. Recurrent networks are dynamic and can handle sequences of varying lengths through a mechanism for updating internal states that considers the entire sequence history. Modern state modifications help diminish vanishing and exploding gradients.
 
 |Model                                       | Point Forecast   | Probabilistic Forecast | Insample fitted values | Probabilistic fitted values  |
@@ -57,7 +59,7 @@ The RNN-based family attempts to leverage the data's temporal structure while re
 |[`DilatedRNN`](../models.dilated_rnn.html)  |✅                |✅                      |✅                      |✅                            |
 : {tbl-colwidths="[25,25]"}
 
-## Transformers Model Family
+### Transformers Model Family
 Transformer architectures are an alternative to recurrent networks. These networks build on the self-attention mechanism that directly allows modeling the relationship between different sequence parts without sequential processing. Attention makes Transformers more parallelizable than RNNs.
 
 |Model                                                      | Point Forecast   | Probabilistic Forecast | Insample fitted values | Probabilistic fitted values  |

--- a/nbs/models.nbeatsx.ipynb
+++ b/nbs/models.nbeatsx.ipynb
@@ -52,6 +52,22 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "25e1718a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#| hide\n",
+    "import os\n",
+    "os.environ[\"PYTORCH_ENABLE_MPS_FALLBACK\"] = \"1\"\n",
+    "\n",
+    "from fastcore.test import test_eq, test_fail\n",
+    "from nbdev.showdoc import show_doc\n",
+    "from neuralforecast.utils import generate_series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "262e6ab4",
    "metadata": {},
    "outputs": [],
@@ -65,19 +81,6 @@
     "\n",
     "from neuralforecast.losses.pytorch import MAE\n",
     "from neuralforecast.common._base_windows import BaseWindows"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2508f7a9-1433-4ad8-8f2f-0078c6ed6c3c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#| hide\n",
-    "from fastcore.test import test_eq\n",
-    "from nbdev.showdoc import show_doc\n",
-    "from neuralforecast.utils import generate_series"
    ]
   },
   {
@@ -350,6 +353,10 @@
     "                 drop_last_loader: bool = False,\n",
     "                 **trainer_kwargs):\n",
     "\n",
+    "        # Protect horizon collapsed seasonality and trend NBEATSx-i basis\n",
+    "        if h==1 and (('seasonality' in stack_types) or ('trend' in stack_types)):\n",
+    "            raise Exception('Horizon `h=1` incompatible with `seasonality` or `trend` in stacks')\n",
+    "\n",
     "        # Inherit BaseWindows class\n",
     "        super(NBEATSx, self).__init__(h=h, \n",
     "                                      input_size = input_size,\n",
@@ -620,6 +627,20 @@
     "#test we recover the same forecast\n",
     "y_hat_test2 = model.predict(dataset=dataset, step_size=1)\n",
     "test_eq(y_hat_test, y_hat_test2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "02d7648e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#| hide\n",
+    "# test seasonality/trend basis protection\n",
+    "test_fail(NBEATSx.__init__, \n",
+    "          contains='Horizon `h=1` incompatible with `seasonality` or `trend` in stacks',\n",
+    "          kwargs=dict(self=BaseWindows, h=1, input_size=4))"
    ]
   },
   {

--- a/neuralforecast/core.py
+++ b/neuralforecast/core.py
@@ -136,6 +136,7 @@ MODEL_FILENAME_DICT = {
     "autodilatedrnn": DilatedRNN,
     "automlp": MLP,
     "autonbeats": NBEATS,
+    "autonbeatsx": NBEATSx,
     "autonhits": NHITS,
     "autotft": TFT,
     "autovanillatransformer": VanillaTransformer,

--- a/neuralforecast/models/nbeatsx.py
+++ b/neuralforecast/models/nbeatsx.py
@@ -3,7 +3,7 @@
 # %% auto 0
 __all__ = ['NBEATSx']
 
-# %% ../../nbs/models.nbeatsx.ipynb 5
+# %% ../../nbs/models.nbeatsx.ipynb 6
 from typing import Tuple, Optional
 
 import numpy as np
@@ -314,6 +314,12 @@ class NBEATSx(BaseWindows):
         drop_last_loader: bool = False,
         **trainer_kwargs,
     ):
+        # Protect horizon collapsed seasonality and trend NBEATSx-i basis
+        if h == 1 and (("seasonality" in stack_types) or ("trend" in stack_types)):
+            raise Exception(
+                "Horizon `h=1` incompatible with `seasonality` or `trend` in stacks"
+            )
+
         # Inherit BaseWindows class
         super(NBEATSx, self).__init__(
             h=h,


### PR DESCRIPTION
- Added NBEATSx-i horizon=1 protection, `h=1` collapses the trend and seasonality basis.
- Added autonbeatsx entry to MODEL_FILENAME_DICT in core.py