### PR TITLE
[FIX] MinMax scalers NaN when masked

### DIFF
--- a/nbs/common.scalers.ipynb
+++ b/nbs/common.scalers.ipynb
@@ -23,6 +23,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "56742bfb",
    "metadata": {},
@@ -33,6 +34,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "9319296d",
    "metadata": {},
@@ -69,6 +71,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "ef461e9c",
    "metadata": {},
@@ -150,6 +153,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "a7a486a2",
    "metadata": {},
@@ -186,10 +190,13 @@
     "    **Returns:**<br>\n",
     "    `z`: torch.Tensor same shape as `x`, except scaled.\n",
     "    \"\"\"\n",
-    "    max_mask = (mask==0) * (-1e12)\n",
-    "    min_mask = (mask==0) * (1e12)\n",
-    "    x_max = torch.max(x + max_mask, dim=dim, keepdim=True)[0]\n",
-    "    x_min = torch.min(x + min_mask, dim=dim, keepdim=True)[0]\n",
+    "    mask = mask.clone()\n",
+    "    mask[mask==0] = torch.inf\n",
+    "    mask[mask==1] = 0\n",
+    "    x_max = torch.max(torch.nan_to_num(x-mask,nan=-torch.inf), dim=dim, keepdim=True)[0]\n",
+    "    x_min = torch.min(torch.nan_to_num(x+mask,nan=torch.inf), dim=dim, keepdim=True)[0]\n",
+    "    x_max = x_max.type(x.dtype)\n",
+    "    x_min = x_min.type(x.dtype)\n",
     "\n",
     "    # x_range and prevent division by zero\n",
     "    x_range = x_max - x_min\n",
@@ -251,11 +258,15 @@
     "    **Returns:**<br>\n",
     "    `z`: torch.Tensor same shape as `x`, except scaled.\n",
     "    \"\"\"\n",
-    "    max_mask = (mask==0) * (-1e12)\n",
-    "    min_mask = (mask==0) * (1e12)\n",
-    "    x_max = torch.max(x + max_mask, dim=dim, keepdim=True)[0]\n",
-    "    x_min = torch.min(x + min_mask, dim=dim, keepdim=True)[0]\n",
-    "\n",
+    "    # Mask values (set masked to -inf or +inf)\n",
+    "    mask = mask.clone()\n",
+    "    mask[mask==0] = torch.inf\n",
+    "    mask[mask==1] = 0\n",
+    "    x_max = torch.max(torch.nan_to_num(x-mask,nan=-torch.inf), dim=dim, keepdim=True)[0]\n",
+    "    x_min = torch.min(torch.nan_to_num(x+mask,nan=torch.inf), dim=dim, keepdim=True)[0]\n",
+    "    x_max = x_max.type(x.dtype)\n",
+    "    x_min = x_min.type(x.dtype)\n",
+    "    \n",
     "    # x_range and prevent division by zero\n",
     "    x_range = x_max - x_min\n",
     "    x_range[x_range==0] = 1.0\n",
@@ -554,6 +565,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "e87e828c",
    "metadata": {},
@@ -678,6 +690,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "3e2968e0",
    "metadata": {},
@@ -772,19 +785,47 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "fb1207bd",
+   "metadata": {},
+   "source": [
+    "# Test Predict (masked)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "3d1b72a8",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "#| hide\n",
+    "import pandas as pd\n",
+    "\n",
+    "from neuralforecast import NeuralForecast\n",
+    "from neuralforecast.models import NHITS\n",
+    "from neuralforecast.utils import AirPassengersDF as Y_df\n",
+    "\n",
+    "model = NHITS(h=12,\n",
+    "              input_size=12*2,\n",
+    "              max_steps=1,\n",
+    "              windows_batch_size=None, \n",
+    "              n_freq_downsample=[1,1,1],\n",
+    "              scaler_type='minmax')\n",
+    "\n",
+    "nf = NeuralForecast(models=[model], freq='M')\n",
+    "nf.fit(df=Y_df)\n",
+    "Y_hat = nf.predict(df=Y_df)\n",
+    "assert pd.isnull(Y_hat).sum().sum() == 0, 'Predictions should not have NaNs'"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "neuralforecast",
+   "display_name": "python3",
    "language": "python",
-   "name": "neuralforecast"
+   "name": "python3"
   }
  },
  "nbformat": 4,

--- a/neuralforecast/common/_scalers.py
+++ b/neuralforecast/common/_scalers.py
@@ -76,10 +76,17 @@ def minmax_scaler(x, mask, eps=1e-6, dim=-1):
     **Returns:**<br>
     `z`: torch.Tensor same shape as `x`, except scaled.
     """
-    max_mask = (mask == 0) * (-1e12)
-    min_mask = (mask == 0) * (1e12)
-    x_max = torch.max(x + max_mask, dim=dim, keepdim=True)[0]
-    x_min = torch.min(x + min_mask, dim=dim, keepdim=True)[0]
+    mask = mask.clone()
+    mask[mask == 0] = torch.inf
+    mask[mask == 1] = 0
+    x_max = torch.max(
+        torch.nan_to_num(x - mask, nan=-torch.inf), dim=dim, keepdim=True
+    )[0]
+    x_min = torch.min(torch.nan_to_num(x + mask, nan=torch.inf), dim=dim, keepdim=True)[
+        0
+    ]
+    x_max = x_max.type(x.dtype)
+    x_min = x_min.type(x.dtype)
 
     # x_range and prevent division by zero
     x_range = x_max - x_min
@@ -115,10 +122,18 @@ def minmax1_scaler(x, mask, eps=1e-6, dim=-1):
     **Returns:**<br>
     `z`: torch.Tensor same shape as `x`, except scaled.
     """
-    max_mask = (mask == 0) * (-1e12)
-    min_mask = (mask == 0) * (1e12)
-    x_max = torch.max(x + max_mask, dim=dim, keepdim=True)[0]
-    x_min = torch.min(x + min_mask, dim=dim, keepdim=True)[0]
+    # Mask values (set masked to -inf or +inf)
+    mask = mask.clone()
+    mask[mask == 0] = torch.inf
+    mask[mask == 1] = 0
+    x_max = torch.max(
+        torch.nan_to_num(x - mask, nan=-torch.inf), dim=dim, keepdim=True
+    )[0]
+    x_min = torch.min(torch.nan_to_num(x + mask, nan=torch.inf), dim=dim, keepdim=True)[
+        0
+    ]
+    x_max = x_max.type(x.dtype)
+    x_min = x_min.type(x.dtype)
 
     # x_range and prevent division by zero
     x_range = x_max - x_min


### PR DESCRIPTION
Fix a bug where `minmax` and `minmax1` scalers return NaN if some values in the input tensor are masked.