### PR TITLE
[Bug] Fixed the sparse tutorial neuralforecast installation

### DIFF
--- a/nbs/examples/IntermittentData.ipynb
+++ b/nbs/examples/IntermittentData.ipynb
@@ -73,7 +73,17 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "!pip install neuralforecast statsforecast s3fs fastparquet"
+    "!pip install statsforecast s3fs fastparquet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "!pip install git+https://github.com/Nixtla/neuralforecast.git"
    ]
   },
   {


### PR DESCRIPTION
The GPU code execution in the pip version of the library is bugged.
We need to update the pip soon with a new version for neuralforecast.

A partial/momentary fix is to install from the git main branch directly.
