### PR TITLE
[FIX] Change default of `use_init_models`

### DIFF
--- a/nbs/core.ipynb
+++ b/nbs/core.ipynb
@@ -298,7 +298,7 @@
     "            static_df: Optional[pd.DataFrame] = None,\n",
     "            val_size: Optional[int] = 0,\n",
     "            sort_df: bool = True,\n",
-    "            use_init_models: bool = True,\n",
+    "            use_init_models: bool = False,\n",
     "            verbose: bool = False):\n",
     "        \"\"\"Fit the core.NeuralForecast.\n",
     "\n",
@@ -316,7 +316,7 @@
     "            Size of validation set.\n",
     "        sort_df : bool, optional (default=False)\n",
     "            Sort `df` before fitting.\n",
-    "        use_init_models : bool, optional (default=True)\n",
+    "        use_init_models : bool, optional (default=False)\n",
     "            Use initial model passed when NeuralForecast object was instantiated.\n",
     "        verbose : bool (default=False)\n",
     "            Print processing steps.\n",
@@ -349,6 +349,8 @@
     "        # Recover initial model if use_init_models or is the first time fitting\n",
     "        if (use_init_models) or (not self._fitted):\n",
     "            self.models_fitted = [deepcopy(model) for model in self.models]\n",
+    "            if self._fitted:\n",
+    "                print('WARNING: Deleting previously fitted models.')\n",
     "\n",
     "        for model in self.models_fitted:\n",
     "            model.fit(self.dataset, val_size=val_size)\n",
@@ -448,7 +450,7 @@
     "                         val_size: Optional[int] = 0, \n",
     "                         test_size: Optional[int] = None,\n",
     "                         sort_df: bool = True,\n",
-    "                         use_init_models: bool = True,\n",
+    "                         use_init_models: bool = False,\n",
     "                         verbose: bool = False,\n",
     "                         **data_kwargs):\n",
     "        \"\"\"Temporal Cross-Validation with core.NeuralForecast.\n",
@@ -473,7 +475,7 @@
     "            Length of test size. If passed, set `n_windows=None`.\n",
     "        sort_df : bool (default=True)\n",
     "            Sort `df` before fitting.\n",
-    "        use_init_models : bool, option (default=True)\n",
+    "        use_init_models : bool, option (default=False)\n",
     "            Use initial model passed when object was instantiated.\n",
     "        verbose : bool (default=False)\n",
     "            Print processing steps.\n",
@@ -499,6 +501,8 @@
     "        # Recover initial model if use_init_models and not fitted. If already fitted, will use models_fitted\n",
     "        if (use_init_models) or (not self._fitted):\n",
     "            self.models_fitted = [deepcopy(model) for model in self.models]\n",
+    "            if self._fitted:\n",
+    "                print('WARNING: Deleting previously fitted models.')\n",
     "\n",
     "        cols = []\n",
     "        count_names = {'model': 0}\n",
@@ -915,9 +919,9 @@
     "nf = NeuralForecast(models=models, freq='M')\n",
     "nf.fit(AirPassengersPanel_train)\n",
     "init_fcst = nf.predict()\n",
-    "init_cv = nf.cross_validation(AirPassengersPanel_train)\n",
-    "after_cv = nf.cross_validation(AirPassengersPanel_train)\n",
-    "nf.fit(AirPassengersPanel_train)\n",
+    "init_cv = nf.cross_validation(AirPassengersPanel_train, use_init_models=True)\n",
+    "after_cv = nf.cross_validation(AirPassengersPanel_train, use_init_models=True)\n",
+    "nf.fit(AirPassengersPanel_train, use_init_models=True)\n",
     "after_fcst = nf.predict()\n",
     "test_eq(init_cv, after_cv)\n",
     "test_eq(init_fcst, after_fcst)"
@@ -935,7 +939,7 @@
     "models = [MLP(h=12, input_size=12, max_steps=1, scaler_type='robust')]\n",
     "initial_weights = models[0].mlp[0].weight.detach().clone()\n",
     "fcst = NeuralForecast(models=models, freq='M')\n",
-    "fcst.fit(df=AirPassengersPanel_train, static_df=AirPassengersStatic)\n",
+    "fcst.fit(df=AirPassengersPanel_train, static_df=AirPassengersStatic, use_init_models=True)\n",
     "after_weights = models[0].mlp[0].weight.detach().clone()\n",
     "np.allclose(initial_weights, after_weights)"
    ]
@@ -1369,6 +1373,14 @@
     "AirPassengersShort = AirPassengersPanel.tail(36+144).reset_index(drop=True)\n",
     "forecasts = fcst.cross_validation(AirPassengersShort, val_size=48, n_windows=1)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cadac88d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/neuralforecast/core.py
+++ b/neuralforecast/core.py
@@ -194,7 +194,7 @@ class NeuralForecast:
         static_df: Optional[pd.DataFrame] = None,
         val_size: Optional[int] = 0,
         sort_df: bool = True,
-        use_init_models: bool = True,
+        use_init_models: bool = False,
         verbose: bool = False,
     ):
         """Fit the core.NeuralForecast.
@@ -213,7 +213,7 @@ class NeuralForecast:
             Size of validation set.
         sort_df : bool, optional (default=False)
             Sort `df` before fitting.
-        use_init_models : bool, optional (default=True)
+        use_init_models : bool, optional (default=False)
             Use initial model passed when NeuralForecast object was instantiated.
         verbose : bool (default=False)
             Print processing steps.
@@ -251,6 +251,8 @@ class NeuralForecast:
         # Recover initial model if use_init_models or is the first time fitting
         if (use_init_models) or (not self._fitted):
             self.models_fitted = [deepcopy(model) for model in self.models]
+            if self._fitted:
+                print("WARNING: Deleting previously fitted models.")
 
         for model in self.models_fitted:
             model.fit(self.dataset, val_size=val_size)
@@ -361,7 +363,7 @@ class NeuralForecast:
         val_size: Optional[int] = 0,
         test_size: Optional[int] = None,
         sort_df: bool = True,
-        use_init_models: bool = True,
+        use_init_models: bool = False,
         verbose: bool = False,
         **data_kwargs,
     ):
@@ -387,7 +389,7 @@ class NeuralForecast:
             Length of test size. If passed, set `n_windows=None`.
         sort_df : bool (default=True)
             Sort `df` before fitting.
-        use_init_models : bool, option (default=True)
+        use_init_models : bool, option (default=False)
             Use initial model passed when object was instantiated.
         verbose : bool (default=False)
             Print processing steps.
@@ -416,6 +418,8 @@ class NeuralForecast:
         # Recover initial model if use_init_models and not fitted. If already fitted, will use models_fitted
         if (use_init_models) or (not self._fitted):
             self.models_fitted = [deepcopy(model) for model in self.models]
+            if self._fitted:
+                print("WARNING: Deleting previously fitted models.")
 
         cols = []
         count_names = {"model": 0}


### PR DESCRIPTION
Change the default value of `use_init_models` to False to fine-tune as the default behavior.

Print warning when the previously fitted model is deleted. 