### PR TITLE
remove branch from pip install in predictive maintenance example

### DIFF
--- a/nbs/examples/Predictive_Maintenance.ipynb
+++ b/nbs/examples/Predictive_Maintenance.ipynb
@@ -53,7 +53,7 @@
    "outputs": [],
    "source": [
     "# %%capture\n",
-    "# !pip install git+https://github.com/Nixtla/datasetsforecast.git@predictive_maintenance"
+    "# !pip install git+https://github.com/Nixtla/datasetsforecast.git"
    ]
   },
   {


### PR DESCRIPTION
Fixes the issue reported in #732. 