### PR TITLE
update actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
 
       - name: Install nbdev
         run: pip install nbdev
@@ -45,14 +45,14 @@ jobs:
         python-version: [3.8, 3.9, '3.10']
     steps:
       - name: Clone repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up environment
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/setup-micromamba@v1
         with:
-          extra-specs: python=${{ matrix.python-version }}
-          cache-env: true
-          channel-priority: 'flexible'
+          environment-file: environment.yml
+          create-args: python=${{ matrix.python-version }}
+          cache-environment: true
       
       - name: Install pip requirements
         run: pip install ./ 


### PR DESCRIPTION
Updates the versions of the following github actions:
* setup-python: v2 -> v4
* checkout: v2 -> v3

Also replaces the now deprecated provision-with-micromamba action with setup-micromamba