### PR TITLE
increase relative tolerance for minmax test

### DIFF
--- a/nbs/core.ipynb
+++ b/nbs/core.ipynb
@@ -1097,7 +1097,7 @@
     "np.testing.assert_allclose(\n",
     "    insample_res['NHITS'].values,\n",
     "    insample_res_exog['NHITS'].values,\n",
-    "    rtol=0.1,\n",
+    "    rtol=0.2,\n",
     ")"
    ]
   },


### PR DESCRIPTION
The denominator for the minmax scaler in utilsforecast was wrong, which was fixed in https://github.com/Nixtla/utilsforecast/pull/16 and added to v0.0.7. However, using the right denominator seems to have increased a bit the relative difference between the predictions with and without exogenous features in a test. This increases the tolerance for that test.