### PR TITLE
split import cell in common_scalers

### DIFF
--- a/nbs/common.scalers.ipynb
+++ b/nbs/common.scalers.ipynb
@@ -895,19 +895,27 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fa6e6a40",
+   "id": "383f05b4-e921-4fa6-b2a1-65105b5eebd0",
    "metadata": {},
    "outputs": [],
    "source": [
     "#| hide\n",
-    "\n",
-    "# Unit test for ReVIN, and its compatibility with distribution's scale decouple\n",
     "from neuralforecast import NeuralForecast\n",
     "from neuralforecast.models import NHITS, RNN\n",
     "from neuralforecast.losses.pytorch import DistributionLoss, HuberLoss, GMM, MAE\n",
     "from neuralforecast.tsdataset import TimeSeriesDataset\n",
-    "from neuralforecast.utils import AirPassengers, AirPassengersPanel, AirPassengersStatic\n",
-    "\n",
+    "from neuralforecast.utils import AirPassengers, AirPassengersPanel, AirPassengersStatic"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fb2095d2-74d4-4b94-bee3-c049aac8494d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#| hide\n",
+    "# Unit test for ReVIN, and its compatibility with distribution's scale decouple\n",
     "Y_df = AirPassengersPanel\n",
     "# del Y_df['trend']\n",
     "\n",

--- a/nbs/common.scalers.ipynb
+++ b/nbs/common.scalers.ipynb
@@ -858,19 +858,27 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3d1b72a8",
+   "id": "17e3dbfc-2677-4d1f-85bc-de6343196045",
    "metadata": {},
    "outputs": [],
    "source": [
     "#| hide\n",
-    "\n",
-    "# Unit test for masked predict filtering\n",
     "import pandas as pd\n",
     "\n",
     "from neuralforecast import NeuralForecast\n",
     "from neuralforecast.models import NHITS\n",
-    "from neuralforecast.utils import AirPassengersDF as Y_df\n",
-    "\n",
+    "from neuralforecast.utils import AirPassengersDF as Y_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28e5f23d-9a64-4d77-8a27-55fcc765d0b7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#| hide\n",
+    "# Unit test for masked predict filtering\n",
     "model = NHITS(h=12,\n",
     "              input_size=12*2,\n",
     "              max_steps=1,\n",


### PR DESCRIPTION
Splits the import cell in `nbs/common.scalers.ipynb` so that the test doesn't run when building the docs.