### PR TITLE
redirect to mintlify docs

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -14,9 +14,14 @@ jobs:
   build-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Clone repo
+        uses: actions/checkout@v3
+      - name: Clone docs repo
+        uses: actions/checkout@v3
         with:
-          submodules: 'recursive'
+          repository: Nixtla/docs
+          ref: scripts
+          path: docs-scripts
       - uses: actions/setup-python@v4
         with:
           cache: "pip"
@@ -45,7 +50,16 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: docs
           publish_dir: ./_docs
-          # The following lines assign commit authorship to the official GH-Actions bot for deploys to `docs` branch.
-          # You can swap them out with your own user credentials.
+          user_name: github-actions[bot]
+          user_email: 41898282+github-actions[bot]@users.noreply.github.com
+      - name: Configure redirects for gh-pages
+        run: python docs-scripts/configure-redirects.py neuralforecast
+      - name: Deploy to Github Pages
+        if: github.event_name == 'push'
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./gh-pages
           user_name: github-actions[bot]
           user_email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,9 +1,0 @@
-name: Deploy to GitHub Pages
-on:
-  push:
-    branches: ["main"]
-  workflow_dispatch:
-jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    steps: [uses: fastai/workflows/quarto-ghp@master]

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "docs-scripts"]
-	path = docs-scripts
-	url = https://github.com/Nixtla/docs.git
-	branch = scripts

--- a/nbs/core.ipynb
+++ b/nbs/core.ipynb
@@ -28,7 +28,7 @@
    "id": "12fa25a4",
    "metadata": {},
    "source": [
-    "# <span style=\"color:DarkOrange\"> Core </span>\n",
+    "# Core\n",
     "> NeuralForecast contains two main components, PyTorch implementations deep learning predictive models, as well as parallelization and distributed computation utilities. The first component comprises low-level PyTorch model estimator classes like `models.NBEATS` and `models.RNN`. The second component is a high-level `core.NeuralForecast` wrapper class that operates with sets of time series data stored in pandas DataFrames."
    ]
   },

--- a/nbs/mint.json
+++ b/nbs/mint.json
@@ -70,7 +70,6 @@
       "pages": [
         "core.html",
         "models.html",
-        "models.html",
         {
           "group": "Models' Documentation",
           "pages": [

--- a/nbs/models.ipynb
+++ b/nbs/models.ipynb
@@ -119,7 +119,7 @@
    "id": "7ae65ca7",
    "metadata": {},
    "source": [
-    "# <span style=\"color:DarkOrange\"> Models </span>\n",
+    "# Models\n",
     "\n",
     "> NeuralForecast contains user-friendly implementations of neural forecasting models that allow for easy transition of computing capabilities (GPU/CPU), computation parallelization, and hyperparameter tuning.<br><br> All the NeuralForecast models are \"global\" because we train them with all the series from the input pd.DataFrame data `Y_df`, yet the optimization objective is, momentarily, \"univariate\" as it does not consider the interaction between the output predictions across time series. Like the StatsForecast library, `core.NeuralForecast` allows you to explore collections of models efficiently and contains functions for convenient wrangling of input and output pd.DataFrames predictions."
    ]


### PR DESCRIPTION
Makes the documentation at https://nixtla.github.io/neuralforecast redirect to https://nixtla.mintlify.app/neuralforecast. Also replaces the submodule Nixtla/docs with a checkout.

Also fixes #818