### PR TITLE
split import cells and remove env variables from notebooks

### DIFF
--- a/nbs/common.base_auto.ipynb
+++ b/nbs/common.base_auto.ipynb
@@ -529,12 +529,6 @@
    "outputs": [],
    "source": [
     "#| hide\n",
-    "\n",
-    "#| hide\n",
-    "import os\n",
-    "os.environ[\"PYTORCH_ENABLE_MPS_FALLBACK\"] = \"1\"\n",
-    "os.environ[\"CUDA_VISIBLE_DEVICES\"] = \"0\"\n",
-    "\n",
     "import optuna\n",
     "import pandas as pd\n",
     "from neuralforecast.models.mlp import MLP\n",
@@ -647,7 +641,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ea77450f",
+   "id": "463d4dc0-b25a-4ce6-9172-5690dc979f0b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -657,8 +651,18 @@
     "from neuralforecast.models.mlp import MLP\n",
     "from neuralforecast.utils import AirPassengersDF as Y_df\n",
     "from neuralforecast.tsdataset import TimeSeriesDataset\n",
-    "from neuralforecast.losses.pytorch import MAE, MSE\n",
-    "\n",
+    "from neuralforecast.losses.pytorch import MAE, MSE"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "882c8331-440a-4758-a56c-07a78c0b1603",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#| hide\n",
+    "# Unit tests to guarantee that losses are correctly instantiated\n",
     "Y_train_df = Y_df[Y_df.ds<='1959-12-31'] # 132 train\n",
     "Y_test_df = Y_df[Y_df.ds>'1959-12-31']   # 12 test\n",
     "\n",

--- a/nbs/common.base_multivariate.ipynb
+++ b/nbs/common.base_multivariate.ipynb
@@ -21,13 +21,19 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "# BaseMultivariate\n",
     "\n",
-    "> The `BaseWindows` class contains standard methods shared across window-based multivariate neural networks; in contrast to recurrent neural networks these models commit to a fixed sequence length input. <br><br>The standard methods include data preprocessing `_normalization`, optimization utilities like parameter initialization, `training_step`, `validation_step`, and shared `fit` and `predict` methods.These shared methods enable all the `neuralforecast.models` compatibility with the `core.NeuralForecast` wrapper class. "
+    "> The `BaseWindows` class contains standard methods shared across window-based multivariate neural networks; in contrast to recurrent neural networks these models commit to a fixed sequence length input."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The standard methods include data preprocessing `_normalization`, optimization utilities like parameter initialization, `training_step`, `validation_step`, and shared `fit` and `predict` methods.These shared methods enable all the `neuralforecast.models` compatibility with the `core.NeuralForecast` wrapper class. "
    ]
   },
   {

--- a/nbs/common.base_recurrent.ipynb
+++ b/nbs/common.base_recurrent.ipynb
@@ -29,12 +29,16 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `BaseRecurrent` class contains standard methods shared across recurrent neural networks; these models possess the ability to process variable-length sequences of inputs through their internal memory states. The class is represented by `LSTM`, `GRU`, and `RNN`, along with other more sophisticated architectures like `MQCNN`.\n",
-    "\n",
+    "> The `BaseRecurrent` class contains standard methods shared across recurrent neural networks; these models possess the ability to process variable-length sequences of inputs through their internal memory states. The class is represented by `LSTM`, `GRU`, and `RNN`, along with other more sophisticated architectures like `MQCNN`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "The standard methods include `TemporalNorm` preprocessing, optimization utilities like parameter initialization, `training_step`, `validation_step`, and shared `fit` and `predict` methods.These shared methods enable all the `neuralforecast.models` compatibility with the `core.NeuralForecast` wrapper class."
    ]
   },

--- a/nbs/common.base_windows.ipynb
+++ b/nbs/common.base_windows.ipynb
@@ -23,14 +23,21 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
-   "id": "12fa25a4",
+   "id": "1e0f9607-d12d-44e5-b2be-91a57a0bca79",
    "metadata": {},
    "source": [
     "# BaseWindows\n",
     "\n",
-    "> The `BaseWindows` class contains standard methods shared across window-based neural networks; in contrast to recurrent neural networks these models commit to a fixed sequence length input. The class is represented by `MLP`, and other more sophisticated architectures like `NBEATS`, and `NHITS`.<br><br>The standard methods include data preprocessing `_normalization`, optimization utilities like parameter initialization, `training_step`, `validation_step`, and shared `fit` and `predict` methods.These shared methods enable all the `neuralforecast.models` compatibility with the `core.NeuralForecast` wrapper class. "
+    "> The `BaseWindows` class contains standard methods shared across window-based neural networks; in contrast to recurrent neural networks these models commit to a fixed sequence length input. The class is represented by `MLP`, and other more sophisticated architectures like `NBEATS`, and `NHITS`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1730a556-1574-40ad-92a2-23b924ceb398",
+   "metadata": {},
+   "source": [
+    "The standard methods include data preprocessing `_normalization`, optimization utilities like parameter initialization, `training_step`, `validation_step`, and shared `fit` and `predict` methods.These shared methods enable all the `neuralforecast.models` compatibility with the `core.NeuralForecast` wrapper class. "
    ]
   },
   {

--- a/nbs/common.base_windows.ipynb
+++ b/nbs/common.base_windows.ipynb
@@ -817,16 +817,25 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b2fd48a7",
+   "id": "8927f2e5-f376-4c99-bb8f-8cbb73efe01e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#| hide\n",
+    "from neuralforecast.losses.pytorch import MAE\n",
+    "from neuralforecast.utils import AirPassengersDF\n",
+    "from neuralforecast.tsdataset import TimeSeriesDataset, TimeSeriesDataModule"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "61490e69-f014-4087-83c5-540d5bd7d458",
    "metadata": {},
    "outputs": [],
    "source": [
     "#| hide\n",
     "# add h=0,1 unit test for _parse_windows \n",
-    "from neuralforecast.losses.pytorch import MAE\n",
-    "from neuralforecast.utils import AirPassengersDF\n",
-    "from neuralforecast.tsdataset import TimeSeriesDataset, TimeSeriesDataModule\n",
-    "\n",
     "# Declare batch\n",
     "AirPassengersDF['x'] = np.array(len(AirPassengersDF))\n",
     "AirPassengersDF['x2'] = np.array(len(AirPassengersDF)) * 2\n",

--- a/nbs/common.scalers.ipynb
+++ b/nbs/common.scalers.ipynb
@@ -43,19 +43,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f5400f41",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#| hide\n",
-    "import os\n",
-    "os.environ[\"PYTORCH_ENABLE_MPS_FALLBACK\"] = \"1\"\n",
-    "os.environ[\"CUDA_VISIBLE_DEVICES\"] = \"0\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "df2cc55a",
    "metadata": {},
    "outputs": [],

--- a/nbs/common.scalers.ipynb
+++ b/nbs/common.scalers.ipynb
@@ -73,7 +73,7 @@
    "id": "ef461e9c",
    "metadata": {},
    "source": [
-    "# <span style=\"color:DarkBlue\"> 1. Auxiliary Functions </span>"
+    "# 1. Auxiliary Functions"
    ]
   },
   {
@@ -154,7 +154,7 @@
    "id": "a7a486a2",
    "metadata": {},
    "source": [
-    "# <span style=\"color:DarkBlue\"> 2. Scalers </span>"
+    "# 2. Scalers"
    ]
   },
   {
@@ -574,7 +574,7 @@
    "id": "e87e828c",
    "metadata": {},
    "source": [
-    "# <span style=\"color:DarkBlue\"> 3. TemporalNorm Module </span>"
+    "# 3. TemporalNorm Module"
    ]
   },
   {
@@ -753,7 +753,7 @@
    "id": "3e2968e0",
    "metadata": {},
    "source": [
-    "# <span style=\"color:DarkBlue\"> Example </span>"
+    "# Example"
    ]
   },
   {

--- a/nbs/common.scalers.ipynb
+++ b/nbs/common.scalers.ipynb
@@ -55,14 +55,23 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b7250387",
+   "id": "0f08562b-88d8-4e92-aeeb-bc9bc4c61ab7",
    "metadata": {},
    "outputs": [],
    "source": [
     "#| hide\n",
     "from nbdev.showdoc import show_doc\n",
-    "import matplotlib.pyplot as plt\n",
-    "\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5201e067-f7c0-4ca3-89a7-d879001b1908",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#| hide\n",
     "plt.rcParams[\"axes.grid\"]=True\n",
     "plt.rcParams['font.family'] = 'serif'\n",
     "plt.rcParams[\"figure.figsize\"] = (4,2)"
@@ -172,8 +181,10 @@
     "    [0,1] range. This transformation is often used as an alternative \n",
     "    to the standard scaler. The scaled features are obtained as:\n",
     "\n",
-    "    $$\\mathbf{z} = (\\mathbf{x}_{[B,T,C]}-\\mathrm{min}({\\mathbf{x}})_{[B,1,C]})/\n",
-    "        (\\mathrm{max}({\\mathbf{x}})_{[B,1,C]}- \\mathrm{min}({\\mathbf{x}})_{[B,1,C]})$$\n",
+    "    $$\n",
+    "    \\mathbf{z} = (\\mathbf{x}_{[B,T,C]}-\\mathrm{min}({\\mathbf{x}})_{[B,1,C]})/\n",
+    "        (\\mathrm{max}({\\mathbf{x}})_{[B,1,C]}- \\mathrm{min}({\\mathbf{x}})_{[B,1,C]})\n",
+    "    $$\n",
     "\n",
     "    **Parameters:**<br>\n",
     "    `x`: torch.Tensor input tensor.<br>\n",

--- a/nbs/common.scalers.ipynb
+++ b/nbs/common.scalers.ipynb
@@ -24,12 +24,30 @@
   },
   {
    "cell_type": "markdown",
-   "id": "56742bfb",
+   "id": "83d112c7-18f8-4f20-acad-34e6de54cebf",
    "metadata": {},
    "source": [
     "# TemporalNorm\n",
     "\n",
-    "> Temporal normalization has proven to be essential in neural forecasting tasks, as it enables network's non-linearities to express themselves. Forecasting scaling methods take particular interest in the temporal dimension where most of the variance dwells, contrary to other deep learning techniques like `BatchNorm` that normalizes across batch and temporal dimensions, and `LayerNorm` that normalizes across the feature dimension. Currently we support the following techniques: `std`, `median`, `norm`, `norm1`, `invariant`, `revin`.<br><br>**References**<br>- [Kin G. Olivares, David Luo, Cristian Challu, Stefania La Vattiata, Max Mergenthaler, Artur Dubrawski (2023). \"HINT: Hierarchical Mixture Networks For Coherent Probabilistic Forecasting\". Neural Information Processing Systems, submitted. Working Paper version available at arxiv.](https://arxiv.org/abs/2305.07089)<br>- [Taesung Kim and Jinhee Kim and Yunwon Tae and Cheonbok Park and Jang-Ho Choi and Jaegul Choo. \"Reversible Instance Normalization for Accurate Time-Series Forecasting against Distribution Shift\". ICLR 2022.](https://openreview.net/pdf?id=cGDAkQo1C0p).<br>- [David Salinas, Valentin Flunkert, Jan Gasthaus, Tim Januschowski (2020). \"DeepAR: Probabilistic forecasting with autoregressive recurrent networks\". International Journal of Forecasting.](https://www.sciencedirect.com/science/article/pii/S0169207019301888)<br>"
+    "> Temporal normalization has proven to be essential in neural forecasting tasks, as it enables network's non-linearities to express themselves. Forecasting scaling methods take particular interest in the temporal dimension where most of the variance dwells, contrary to other deep learning techniques like `BatchNorm` that normalizes across batch and temporal dimensions, and `LayerNorm` that normalizes across the feature dimension. Currently we support the following techniques: `std`, `median`, `norm`, `norm1`, `invariant`, `revin`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fee5e60b-f53b-44ff-9ace-1f5def7b601d",
+   "metadata": {},
+   "source": [
+    "## References"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f9211dd2-99a4-4d67-90cb-bb1f7851685e",
+   "metadata": {},
+   "source": [
+    "* [Kin G. Olivares, David Luo, Cristian Challu, Stefania La Vattiata, Max Mergenthaler, Artur Dubrawski (2023). \"HINT: Hierarchical Mixture Networks For Coherent Probabilistic Forecasting\". Neural Information Processing Systems, submitted. Working Paper version available at arxiv.](https://arxiv.org/abs/2305.07089)\n",
+    "* [Taesung Kim and Jinhee Kim and Yunwon Tae and Cheonbok Park and Jang-Ho Choi and Jaegul Choo. \"Reversible Instance Normalization for Accurate Time-Series Forecasting against Distribution Shift\". ICLR 2022.](https://openreview.net/pdf?id=cGDAkQo1C0p)\n",
+    "* [David Salinas, Valentin Flunkert, Jan Gasthaus, Tim Januschowski (2020). \"DeepAR: Probabilistic forecasting with autoregressive recurrent networks\". International Journal of Forecasting.](https://www.sciencedirect.com/science/article/pii/S0169207019301888)"
    ]
   },
   {

--- a/nbs/core.ipynb
+++ b/nbs/core.ipynb
@@ -40,10 +40,6 @@
    "outputs": [],
    "source": [
     "#| hide\n",
-    "import os\n",
-    "os.environ[\"PYTORCH_ENABLE_MPS_FALLBACK\"] = \"1\"\n",
-    "os.environ[\"CUDA_VISIBLE_DEVICES\"] = \"0\"\n",
-    "\n",
     "import shutil\n",
     "from fastcore.test import test_eq, test_fail\n",
     "from nbdev.showdoc import show_doc\n",
@@ -907,13 +903,23 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8898e349-8000-4668-a1c5-52c03c69e85a",
+   "id": "5d6ef366-daec-4ec6-a2ae-199c6ea39a51",
    "metadata": {},
    "outputs": [],
    "source": [
     "#| hide\n",
     "import logging\n",
-    "import warnings\n",
+    "import warnings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0ac1aa65-40a4-4909-bdfb-1439c30439b8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#| hide\n",
     "logging.getLogger(\"pytorch_lightning\").setLevel(logging.ERROR)\n",
     "warnings.filterwarnings(\"ignore\")"
    ]

--- a/nbs/examples/Neuralforecast_Map.ipynb
+++ b/nbs/examples/Neuralforecast_Map.ipynb
@@ -145,5 +145,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/nbs/losses.numpy.ipynb
+++ b/nbs/losses.numpy.ipynb
@@ -49,6 +49,7 @@
    "outputs": [],
    "source": [
     "#| hide\n",
+    "from IPython.display import Image\n",
     "from nbdev.showdoc import show_doc"
    ]
   },
@@ -59,7 +60,6 @@
    "outputs": [],
    "source": [
     "#| hide\n",
-    "from IPython.display import Image\n",
     "WIDTH = 600\n",
     "HEIGHT = 300"
    ]

--- a/nbs/losses.numpy.ipynb
+++ b/nbs/losses.numpy.ipynb
@@ -100,7 +100,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# <span style=\"color:DarkBlue\">1. Scale-dependent Errors </span>\n",
+    "# 1. Scale-dependent Errors\n",
     "\n",
     "These metrics are on the same scale as the data."
    ]
@@ -304,7 +304,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# <span style=\"color:DarkBlue\"> 2. Percentage errors </span>\n",
+    "# 2. Percentage errors\n",
     "\n",
     "These metrics are unit-free, suitable for comparisons across series."
    ]
@@ -446,7 +446,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# <span style=\"color:DarkBlue\"> 3. Scale-independent Errors </span>\n",
+    "# 3. Scale-independent Errors\n",
     "\n",
     "These metrics measure the relative improvements versus baselines."
    ]
@@ -596,7 +596,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# <span style=\"color:DarkBlue\"> 4. Probabilistic Errors </span>\n",
+    "# 4. Probabilistic Errors\n",
     "\n",
     "These measure absolute deviation non-symmetrically, that produce under/over estimation."
    ]
@@ -763,7 +763,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# <span style=\"color:DarkBlue\"> Examples and Validation </span>"
+    "# Examples and Validation"
    ]
   },
   {

--- a/nbs/losses.pytorch.ipynb
+++ b/nbs/losses.pytorch.ipynb
@@ -166,7 +166,7 @@
    "id": "b8a94d7d",
    "metadata": {},
    "source": [
-    "# <span style=\"color:DarkBlue\">1. Scale-dependent Errors </span>\n",
+    "# 1. Scale-dependent Errors\n",
     "\n",
     "These metrics are on the same scale as the data."
    ]
@@ -433,7 +433,7 @@
    "id": "8bcf5488",
    "metadata": {},
    "source": [
-    "# <span style=\"color:DarkBlue\"> 2. Percentage errors </span>\n",
+    "# 2. Percentage errors\n",
     "\n",
     "These metrics are unit-free, suitable for comparisons across series."
    ]
@@ -617,7 +617,7 @@
    "id": "bc3f2d6f",
    "metadata": {},
    "source": [
-    "# <span style=\"color:DarkBlue\"> 3. Scale-independent Errors </span>\n",
+    "# 3. Scale-independent Errors\n",
     "\n",
     "These metrics measure the relative improvements versus baselines."
    ]
@@ -811,7 +811,7 @@
    "id": "c828438e",
    "metadata": {},
    "source": [
-    "# <span style=\"color:DarkBlue\"> 4. Probabilistic Errors </span>\n",
+    "# 4. Probabilistic Errors\n",
     "\n",
     "These methods use statistical approaches for estimating unknown probability distributions using observed data. \n",
     "\n",
@@ -2664,7 +2664,7 @@
    "id": "a6cf4850",
    "metadata": {},
    "source": [
-    "# <span style=\"color:DarkBlue\"> 5. Robustified Errors </span>\n",
+    "# 5. Robustified Errors\n",
     "\n",
     "This type of errors from robust statistic focus on methods resistant to outliers and violations of assumptions, providing reliable estimates and inferences. Robust estimators are used to reduce the impact of outliers, offering more stable results."
    ]
@@ -3144,7 +3144,7 @@
    "id": "eb99f88b",
    "metadata": {},
    "source": [
-    "# <span style=\"color:DarkBlue\"> 6. Others </span>"
+    "# 6. Others"
    ]
   },
   {

--- a/nbs/models.hint.ipynb
+++ b/nbs/models.hint.ipynb
@@ -47,10 +47,6 @@
    "outputs": [],
    "source": [
     "#| hide\n",
-    "import os\n",
-    "os.environ[\"PYTORCH_ENABLE_MPS_FALLBACK\"] = \"1\"\n",
-    "os.environ[\"CUDA_VISIBLE_DEVICES\"] = \"0\"\n",
-    "\n",
     "from nbdev.showdoc import show_doc\n",
     "from neuralforecast.losses.pytorch import GMM\n",
     "from neuralforecast import NeuralForecast\n",

--- a/nbs/models.ipynb
+++ b/nbs/models.ipynb
@@ -25,19 +25,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cd088010",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#| hide\n",
-    "import os\n",
-    "os.environ[\"PYTORCH_ENABLE_MPS_FALLBACK\"] = \"1\"\n",
-    "os.environ[\"CUDA_VISIBLE_DEVICES\"] = \"0\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "e1167bbe",
    "metadata": {},
    "outputs": [],
@@ -2222,7 +2209,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fd3a085a",
+   "id": "db128f64-b311-479e-bf81-07c3bf9f1a5e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2232,8 +2219,17 @@
     "import matplotlib.pyplot as plt\n",
     "\n",
     "from neuralforecast.tsdataset import TimeSeriesDataset\n",
-    "from neuralforecast.utils import AirPassengersDF as Y_df\n",
-    "\n",
+    "from neuralforecast.utils import AirPassengersDF as Y_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1691fdcc-99e3-472b-ae26-03fb89847227",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#| hide\n",
     "# Split train/test and declare time series dataset\n",
     "Y_train_df = Y_df[Y_df.ds<='1959-12-31'] # 132 train\n",
     "Y_test_df = Y_df[Y_df.ds>'1959-12-31']   # 12 test\n",
@@ -2285,15 +2281,24 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56493784",
+   "id": "0bd1d011-aafb-4b7c-a0a0-0f190b529fa8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#| hide\n",
+    "from neuralforecast.losses.pytorch import GMM, sCRPS"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b7e471ca-a633-4868-be0b-3f2992b6cdc1",
    "metadata": {},
    "outputs": [],
    "source": [
     "#| hide\n",
     "## TODO: Add unit tests for interactions between loss/valid_loss types\n",
     "## TODO: Unit tests (2 types of networks x 2 types of loss x 2 types of valid loss)\n",
-    "from neuralforecast.losses.pytorch import GMM, sCRPS\n",
-    "\n",
     "## Checking if base recurrent methods run point valid_loss correctly\n",
     "tcn_config = {\n",
     "       \"learning_rate\": tune.choice([1e-3]),                                     # Initial Learning rate\n",

--- a/nbs/models.nbeatsx.ipynb
+++ b/nbs/models.nbeatsx.ipynb
@@ -57,9 +57,6 @@
    "outputs": [],
    "source": [
     "#| hide\n",
-    "import os\n",
-    "os.environ[\"PYTORCH_ENABLE_MPS_FALLBACK\"] = \"1\"\n",
-    "\n",
     "from fastcore.test import test_eq, test_fail\n",
     "from nbdev.showdoc import show_doc\n",
     "from neuralforecast.utils import generate_series"

--- a/nbs/models.nhits.ipynb
+++ b/nbs/models.nhits.ipynb
@@ -58,18 +58,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#| hide\n",
-    "import os\n",
-    "os.environ[\"PYTORCH_ENABLE_MPS_FALLBACK\"] = \"1\"\n",
-    "os.environ[\"CUDA_VISIBLE_DEVICES\"] = \"0\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "#| export\n",
     "from typing import Tuple, Optional\n",
     "\n",

--- a/nbs/utils.ipynb
+++ b/nbs/utils.ipynb
@@ -59,7 +59,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# <span style=\"color:DarkBlue\">1. Synthetic Panel Data </span>"
+    "# 1. Synthetic Panel Data"
    ]
   },
   {
@@ -185,7 +185,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# <span style=\"color:DarkBlue\">2. AirPassengers Data </span>\n",
+    "# 2. AirPassengers Data\n",
     "\n",
     "The classic Box & Jenkins airline data. Monthly totals of international airline passengers, 1949 to 1960.\n",
     "\n",
@@ -289,7 +289,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# <span style=\"color:DarkBlue\">3. Panel AirPassengers Data </span>\n",
+    "# 3. Panel AirPassengers Data\n",
     "\n",
     "Extension to classic Box & Jenkins airline data. Monthly totals of international airline passengers, 1949 to 1960.\n",
     "\n",

--- a/neuralforecast/auto.py
+++ b/neuralforecast/auto.py
@@ -5,7 +5,7 @@ __all__ = ['AutoRNN', 'AutoLSTM', 'AutoGRU', 'AutoTCN', 'AutoDeepAR', 'AutoDilat
            'AutoNHITS', 'AutoTFT', 'AutoVanillaTransformer', 'AutoInformer', 'AutoAutoformer', 'AutoFEDformer',
            'AutoPatchTST', 'AutoTimesNet', 'AutoStemGNN', 'AutoHINT']
 
-# %% ../nbs/models.ipynb 3
+# %% ../nbs/models.ipynb 2
 from os import cpu_count
 import torch
 
@@ -39,7 +39,7 @@ from .models.hint import HINT
 
 from .losses.pytorch import MAE, MQLoss, DistributionLoss
 
-# %% ../nbs/models.ipynb 10
+# %% ../nbs/models.ipynb 9
 class AutoRNN(BaseAuto):
     default_config = {
         "input_size_multiplier": [-1, 4, 16, 64],
@@ -108,7 +108,7 @@ class AutoRNN(BaseAuto):
             callbacks=callbacks,
         )
 
-# %% ../nbs/models.ipynb 15
+# %% ../nbs/models.ipynb 14
 class AutoLSTM(BaseAuto):
     default_config = {
         "input_size_multiplier": [-1, 4, 16, 64],
@@ -172,7 +172,7 @@ class AutoLSTM(BaseAuto):
             callbacks=callbacks,
         )
 
-# %% ../nbs/models.ipynb 18
+# %% ../nbs/models.ipynb 17
 class AutoGRU(BaseAuto):
     default_config = {
         "input_size_multiplier": [-1, 4, 16, 64],
@@ -238,7 +238,7 @@ class AutoGRU(BaseAuto):
             callbacks=callbacks,
         )
 
-# %% ../nbs/models.ipynb 21
+# %% ../nbs/models.ipynb 20
 class AutoTCN(BaseAuto):
     default_config = {
         "input_size_multiplier": [-1, 4, 16, 64],
@@ -303,7 +303,7 @@ class AutoTCN(BaseAuto):
             callbacks=callbacks,
         )
 
-# %% ../nbs/models.ipynb 24
+# %% ../nbs/models.ipynb 23
 class AutoDeepAR(BaseAuto):
     default_config = {
         "input_size_multiplier": [1, 2, 3, 4, 5],
@@ -369,7 +369,7 @@ class AutoDeepAR(BaseAuto):
             callbacks=callbacks,
         )
 
-# %% ../nbs/models.ipynb 27
+# %% ../nbs/models.ipynb 26
 class AutoDilatedRNN(BaseAuto):
     default_config = {
         "input_size_multiplier": [-1, 4, 16, 64],
@@ -436,7 +436,7 @@ class AutoDilatedRNN(BaseAuto):
             callbacks=callbacks,
         )
 
-# %% ../nbs/models.ipynb 31
+# %% ../nbs/models.ipynb 30
 class AutoMLP(BaseAuto):
     default_config = {
         "input_size_multiplier": [1, 2, 3, 4, 5],
@@ -499,7 +499,7 @@ class AutoMLP(BaseAuto):
             callbacks=callbacks,
         )
 
-# %% ../nbs/models.ipynb 34
+# %% ../nbs/models.ipynb 33
 class AutoNBEATS(BaseAuto):
     default_config = {
         "input_size_multiplier": [1, 2, 3, 4, 5],
@@ -560,7 +560,7 @@ class AutoNBEATS(BaseAuto):
             callbacks=callbacks,
         )
 
-# %% ../nbs/models.ipynb 37
+# %% ../nbs/models.ipynb 36
 class AutoNBEATSx(BaseAuto):
     default_config = {
         "input_size_multiplier": [1, 2, 3, 4, 5],
@@ -621,7 +621,7 @@ class AutoNBEATSx(BaseAuto):
             callbacks=callbacks,
         )
 
-# %% ../nbs/models.ipynb 40
+# %% ../nbs/models.ipynb 39
 class AutoNHITS(BaseAuto):
     default_config = {
         "input_size_multiplier": [1, 2, 3, 4, 5],
@@ -695,7 +695,7 @@ class AutoNHITS(BaseAuto):
             callbacks=callbacks,
         )
 
-# %% ../nbs/models.ipynb 44
+# %% ../nbs/models.ipynb 43
 class AutoTFT(BaseAuto):
     default_config = {
         "input_size_multiplier": [1, 2, 3, 4, 5],
@@ -758,7 +758,7 @@ class AutoTFT(BaseAuto):
             callbacks=callbacks,
         )
 
-# %% ../nbs/models.ipynb 47
+# %% ../nbs/models.ipynb 46
 class AutoVanillaTransformer(BaseAuto):
     default_config = {
         "input_size_multiplier": [1, 2, 3, 4, 5],
@@ -821,7 +821,7 @@ class AutoVanillaTransformer(BaseAuto):
             callbacks=callbacks,
         )
 
-# %% ../nbs/models.ipynb 50
+# %% ../nbs/models.ipynb 49
 class AutoInformer(BaseAuto):
     default_config = {
         "input_size_multiplier": [1, 2, 3, 4, 5],
@@ -884,7 +884,7 @@ class AutoInformer(BaseAuto):
             callbacks=callbacks,
         )
 
-# %% ../nbs/models.ipynb 53
+# %% ../nbs/models.ipynb 52
 class AutoAutoformer(BaseAuto):
     default_config = {
         "input_size_multiplier": [1, 2, 3, 4, 5],
@@ -947,7 +947,7 @@ class AutoAutoformer(BaseAuto):
             callbacks=callbacks,
         )
 
-# %% ../nbs/models.ipynb 56
+# %% ../nbs/models.ipynb 55
 class AutoFEDformer(BaseAuto):
     default_config = {
         "input_size_multiplier": [1, 2, 3, 4, 5],
@@ -1009,7 +1009,7 @@ class AutoFEDformer(BaseAuto):
             callbacks=callbacks,
         )
 
-# %% ../nbs/models.ipynb 59
+# %% ../nbs/models.ipynb 58
 class AutoPatchTST(BaseAuto):
     default_config = {
         "input_size_multiplier": [1, 2, 3],
@@ -1074,7 +1074,7 @@ class AutoPatchTST(BaseAuto):
             callbacks=callbacks,
         )
 
-# %% ../nbs/models.ipynb 63
+# %% ../nbs/models.ipynb 62
 class AutoTimesNet(BaseAuto):
     default_config = {
         "input_size_multiplier": [1, 2, 3, 4, 5],
@@ -1137,7 +1137,7 @@ class AutoTimesNet(BaseAuto):
             callbacks=callbacks,
         )
 
-# %% ../nbs/models.ipynb 67
+# %% ../nbs/models.ipynb 66
 class AutoStemGNN(BaseAuto):
     default_config = {
         "input_size_multiplier": [1, 2, 3, 4],
@@ -1204,7 +1204,7 @@ class AutoStemGNN(BaseAuto):
             callbacks=callbacks,
         )
 
-# %% ../nbs/models.ipynb 71
+# %% ../nbs/models.ipynb 70
 class AutoHINT(BaseAuto):
     def __init__(
         self,

--- a/neuralforecast/common/_base_multivariate.py
+++ b/neuralforecast/common/_base_multivariate.py
@@ -3,7 +3,7 @@
 # %% auto 0
 __all__ = ['BaseMultivariate']
 
-# %% ../../nbs/common.base_multivariate.ipynb 4
+# %% ../../nbs/common.base_multivariate.ipynb 5
 import random
 import warnings
 
@@ -17,7 +17,7 @@ from pytorch_lightning.callbacks.early_stopping import EarlyStopping
 from ._scalers import TemporalNorm
 from ..tsdataset import TimeSeriesDataModule
 
-# %% ../../nbs/common.base_multivariate.ipynb 5
+# %% ../../nbs/common.base_multivariate.ipynb 6
 class BaseMultivariate(pl.LightningModule):
     """Base Multivariate
 

--- a/neuralforecast/common/_base_recurrent.py
+++ b/neuralforecast/common/_base_recurrent.py
@@ -3,7 +3,7 @@
 # %% auto 0
 __all__ = ['BaseRecurrent']
 
-# %% ../../nbs/common.base_recurrent.ipynb 5
+# %% ../../nbs/common.base_recurrent.ipynb 6
 import random
 import warnings
 
@@ -17,7 +17,7 @@ from pytorch_lightning.callbacks.early_stopping import EarlyStopping
 from ._scalers import TemporalNorm
 from ..tsdataset import TimeSeriesDataModule
 
-# %% ../../nbs/common.base_recurrent.ipynb 6
+# %% ../../nbs/common.base_recurrent.ipynb 7
 class BaseRecurrent(pl.LightningModule):
     """Base Recurrent
 

--- a/neuralforecast/common/_base_windows.py
+++ b/neuralforecast/common/_base_windows.py
@@ -3,7 +3,7 @@
 # %% auto 0
 __all__ = ['BaseWindows']
 
-# %% ../../nbs/common.base_windows.ipynb 4
+# %% ../../nbs/common.base_windows.ipynb 5
 import random
 import warnings
 
@@ -17,7 +17,7 @@ from pytorch_lightning.callbacks.early_stopping import EarlyStopping
 from ._scalers import TemporalNorm
 from ..tsdataset import TimeSeriesDataModule
 
-# %% ../../nbs/common.base_windows.ipynb 5
+# %% ../../nbs/common.base_windows.ipynb 6
 class BaseWindows(pl.LightningModule):
     """Base Windows
 

--- a/neuralforecast/common/_scalers.py
+++ b/neuralforecast/common/_scalers.py
@@ -4,11 +4,11 @@
 __all__ = ['masked_median', 'masked_mean', 'minmax_statistics', 'minmax1_statistics', 'std_statistics', 'robust_statistics',
            'invariant_statistics', 'identity_statistics', 'TemporalNorm']
 
-# %% ../../nbs/common.scalers.ipynb 5
+# %% ../../nbs/common.scalers.ipynb 6
 import torch
 import torch.nn as nn
 
-# %% ../../nbs/common.scalers.ipynb 8
+# %% ../../nbs/common.scalers.ipynb 10
 def masked_median(x, mask, dim=-1, keepdim=True):
     """Masked Median
 
@@ -54,7 +54,7 @@ def masked_mean(x, mask, dim=-1, keepdim=True):
     x_mean = torch.nan_to_num(x_mean, nan=0.0)
     return x_mean
 
-# %% ../../nbs/common.scalers.ipynb 12
+# %% ../../nbs/common.scalers.ipynb 14
 def minmax_statistics(x, mask, eps=1e-6, dim=-1):
     """MinMax Scaler
 
@@ -62,8 +62,10 @@ def minmax_statistics(x, mask, eps=1e-6, dim=-1):
     [0,1] range. This transformation is often used as an alternative
     to the standard scaler. The scaled features are obtained as:
 
-    $$\mathbf{z} = (\mathbf{x}_{[B,T,C]}-\mathrm{min}({\mathbf{x}})_{[B,1,C]})/
-        (\mathrm{max}({\mathbf{x}})_{[B,1,C]}- \mathrm{min}({\mathbf{x}})_{[B,1,C]})$$
+    $$
+    \mathbf{z} = (\mathbf{x}_{[B,T,C]}-\mathrm{min}({\mathbf{x}})_{[B,1,C]})/
+        (\mathrm{max}({\mathbf{x}})_{[B,1,C]}- \mathrm{min}({\mathbf{x}})_{[B,1,C]})
+    $$
 
     **Parameters:**<br>
     `x`: torch.Tensor input tensor.<br>
@@ -94,7 +96,7 @@ def minmax_statistics(x, mask, eps=1e-6, dim=-1):
     x_range = x_range + eps
     return x_min, x_range
 
-# %% ../../nbs/common.scalers.ipynb 13
+# %% ../../nbs/common.scalers.ipynb 15
 def minmax_scaler(x, x_min, x_range):
     return (x - x_min) / x_range
 
@@ -102,7 +104,7 @@ def minmax_scaler(x, x_min, x_range):
 def inv_minmax_scaler(z, x_min, x_range):
     return z * x_range + x_min
 
-# %% ../../nbs/common.scalers.ipynb 15
+# %% ../../nbs/common.scalers.ipynb 17
 def minmax1_statistics(x, mask, eps=1e-6, dim=-1):
     """MinMax1 Scaler
 
@@ -143,7 +145,7 @@ def minmax1_statistics(x, mask, eps=1e-6, dim=-1):
     x_range = x_range + eps
     return x_min, x_range
 
-# %% ../../nbs/common.scalers.ipynb 16
+# %% ../../nbs/common.scalers.ipynb 18
 def minmax1_scaler(x, x_min, x_range):
     x = (x - x_min) / x_range
     z = x * (2) - 1
@@ -154,7 +156,7 @@ def inv_minmax1_scaler(z, x_min, x_range):
     z = (z + 1) / 2
     return z * x_range + x_min
 
-# %% ../../nbs/common.scalers.ipynb 18
+# %% ../../nbs/common.scalers.ipynb 20
 def std_statistics(x, mask, dim=-1, eps=1e-6):
     """Standard Scaler
 
@@ -184,7 +186,7 @@ def std_statistics(x, mask, dim=-1, eps=1e-6):
     x_stds = x_stds + eps
     return x_means, x_stds
 
-# %% ../../nbs/common.scalers.ipynb 19
+# %% ../../nbs/common.scalers.ipynb 21
 def std_scaler(x, x_means, x_stds):
     return (x - x_means) / x_stds
 
@@ -192,7 +194,7 @@ def std_scaler(x, x_means, x_stds):
 def inv_std_scaler(z, x_mean, x_std):
     return (z * x_std) + x_mean
 
-# %% ../../nbs/common.scalers.ipynb 21
+# %% ../../nbs/common.scalers.ipynb 23
 def robust_statistics(x, mask, dim=-1, eps=1e-6):
     """Robust Median Scaler
 
@@ -234,7 +236,7 @@ def robust_statistics(x, mask, dim=-1, eps=1e-6):
     x_mad = x_mad + eps
     return x_median, x_mad
 
-# %% ../../nbs/common.scalers.ipynb 22
+# %% ../../nbs/common.scalers.ipynb 24
 def robust_scaler(x, x_median, x_mad):
     return (x - x_median) / x_mad
 
@@ -242,7 +244,7 @@ def robust_scaler(x, x_median, x_mad):
 def inv_robust_scaler(z, x_median, x_mad):
     return z * x_mad + x_median
 
-# %% ../../nbs/common.scalers.ipynb 24
+# %% ../../nbs/common.scalers.ipynb 26
 def invariant_statistics(x, mask, dim=-1, eps=1e-6):
     """Invariant Median Scaler
 
@@ -282,7 +284,7 @@ def invariant_statistics(x, mask, dim=-1, eps=1e-6):
     x_mad = x_mad + eps
     return x_median, x_mad
 
-# %% ../../nbs/common.scalers.ipynb 25
+# %% ../../nbs/common.scalers.ipynb 27
 def invariant_scaler(x, x_median, x_mad):
     return torch.arcsinh((x - x_median) / x_mad)
 
@@ -290,7 +292,7 @@ def invariant_scaler(x, x_median, x_mad):
 def inv_invariant_scaler(z, x_median, x_mad):
     return torch.sinh(z) * x_mad + x_median
 
-# %% ../../nbs/common.scalers.ipynb 27
+# %% ../../nbs/common.scalers.ipynb 29
 def identity_statistics(x, mask, dim=-1, eps=1e-6):
     """Identity Scaler
 
@@ -316,7 +318,7 @@ def identity_statistics(x, mask, dim=-1, eps=1e-6):
 
     return x_shift, x_scale
 
-# %% ../../nbs/common.scalers.ipynb 28
+# %% ../../nbs/common.scalers.ipynb 30
 def identity_scaler(x, x_shift, x_scale):
     return x
 
@@ -324,7 +326,7 @@ def identity_scaler(x, x_shift, x_scale):
 def inv_identity_scaler(z, x_shift, x_scale):
     return z
 
-# %% ../../nbs/common.scalers.ipynb 31
+# %% ../../nbs/common.scalers.ipynb 33
 class TemporalNorm(nn.Module):
     """Temporal Normalization
 

--- a/neuralforecast/models/nhits.py
+++ b/neuralforecast/models/nhits.py
@@ -3,7 +3,7 @@
 # %% auto 0
 __all__ = ['NHITS']
 
-# %% ../../nbs/models.nhits.ipynb 6
+# %% ../../nbs/models.nhits.ipynb 5
 from typing import Tuple, Optional
 
 import numpy as np
@@ -14,7 +14,7 @@ import torch.nn.functional as F
 from ..losses.pytorch import MAE
 from ..common._base_windows import BaseWindows
 
-# %% ../../nbs/models.nhits.ipynb 9
+# %% ../../nbs/models.nhits.ipynb 8
 class _IdentityBasis(nn.Module):
     def __init__(
         self,
@@ -68,7 +68,7 @@ class _IdentityBasis(nn.Module):
         forecast = forecast.permute(0, 2, 1)
         return backcast, forecast
 
-# %% ../../nbs/models.nhits.ipynb 10
+# %% ../../nbs/models.nhits.ipynb 9
 ACTIVATIONS = ["ReLU", "Softplus", "Tanh", "SELU", "LeakyReLU", "PReLU", "Sigmoid"]
 
 POOLING = ["MaxPool1d", "AvgPool1d"]
@@ -179,7 +179,7 @@ class NHITSBlock(nn.Module):
         backcast, forecast = self.basis(theta)
         return backcast, forecast
 
-# %% ../../nbs/models.nhits.ipynb 11
+# %% ../../nbs/models.nhits.ipynb 10
 class NHITS(BaseWindows):
     """NHITS
 


### PR DESCRIPTION
* Splits the cell with imports and code so that the code doesn't run when building the documentation.
* Removes the env variables set in the notebooks so that code like `CUDA_VISIBLE_DEVICES='' nbdev_test` allows running the tests on the CPU in a machine with a CUDA GPU.
* Removes the span tags from some of the sections.
* Removes break tags from the descriptions.
* Fixes an equation in the scalers notebook.