### PR TITLE
removed documentation for missing argument

### DIFF
--- a/nbs/models.lstm.ipynb
+++ b/nbs/models.lstm.ipynb
@@ -99,7 +99,6 @@
     "    `inference_input_size`: int, maximum sequence length for truncated inference. Default -1 uses all history.<br>\n",
     "    `encoder_n_layers`: int=2, number of layers for the LSTM.<br>\n",
     "    `encoder_hidden_size`: int=200, units for the LSTM's hidden state size.<br>\n",
-    "    `encoder_activation`: str=`tanh`, type of LSTM activation from `tanh` or `relu`.<br>\n",
     "    `encoder_bias`: bool=True, whether or not to use biases b_ih, b_hh within LSTM units.<br>\n",
     "    `encoder_dropout`: float=0., dropout regularization applied to LSTM outputs.<br>\n",
     "    `context_size`: int=10, size of context vector for each timestamp on the forecasting window.<br>\n",

--- a/neuralforecast/models/lstm.py
+++ b/neuralforecast/models/lstm.py
@@ -28,7 +28,6 @@ class LSTM(BaseRecurrent):
     `inference_input_size`: int, maximum sequence length for truncated inference. Default -1 uses all history.<br>
     `encoder_n_layers`: int=2, number of layers for the LSTM.<br>
     `encoder_hidden_size`: int=200, units for the LSTM's hidden state size.<br>
-    `encoder_activation`: str=`tanh`, type of LSTM activation from `tanh` or `relu`.<br>
     `encoder_bias`: bool=True, whether or not to use biases b_ih, b_hh within LSTM units.<br>
     `encoder_dropout`: float=0., dropout regularization applied to LSTM outputs.<br>
     `context_size`: int=10, size of context vector for each timestamp on the forecasting window.<br>


### PR DESCRIPTION
Closes #910 

Documentation for `LSTM` mentioned `encoder_activation` argument, but it was not present in `__init__`. This PR removes this from the docstring.