### PR TITLE
[FIX] Missing autormok in core.ipynb

### DIFF
--- a/nbs/core.ipynb
+++ b/nbs/core.ipynb
@@ -93,7 +93,7 @@
     "    StemGNN, PatchTST, TimesNet, TimeLLM, TSMixer, TSMixerx,\n",
     "    MLPMultivariate, iTransformer,\n",
     "    BiTCN, TiDE, DeepNPTS, SOFTS,\n",
-    "    TimeMixer, KAN\n",
+    "    TimeMixer, KAN, RMoK\n",
     ")\n",
     "from neuralforecast.common._base_auto import BaseAuto, MockTrial"
    ]
@@ -245,7 +245,8 @@
     "    'deepnpts': DeepNPTS, 'autodeepnpts': DeepNPTS,\n",
     "    'softs': SOFTS, 'autosofts': SOFTS,\n",
     "    'timemixer': TimeMixer, 'autotimemixer': TimeMixer,\n",
-    "    'kan': KAN, 'autokan': KAN\n",
+    "    'kan': KAN, 'autokan': KAN,\n",
+    "    'rmok': RMoK, 'autormok': RMoK\n",
     "}"
    ]
   },

--- a/neuralforecast/core.py
+++ b/neuralforecast/core.py
@@ -66,6 +66,7 @@ from neuralforecast.models import (
     SOFTS,
     TimeMixer,
     KAN,
+    RMoK,
 )
 from .common._base_auto import BaseAuto, MockTrial
 
@@ -190,6 +191,8 @@ MODEL_FILENAME_DICT = {
     "autotimemixer": TimeMixer,
     "kan": KAN,
     "autokan": KAN,
+    "rmok": RMoK,
+    "autormok": RMoK,
 }
 
 # %% ../nbs/core.ipynb 8


### PR DESCRIPTION
Fixes #1166:

Adds RMoK and AutoRMoK in model dict of core.ipynb