### PR TITLE
[FIX] Build docs on release only

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -1,7 +1,7 @@
 name: "build-docs"
 on:
-  push:
-    branches: ["main"]
+  release:
+    types: [released]
   pull_request:
     branches: ["main"]
   workflow_dispatch:

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -46,7 +46,9 @@ jobs:
         run: cp nbs/mint.json _docs/mint.json && cp docs-scripts/imgs/* _docs/
 
       - name: Deploy to Mintlify Docs
-        if: github.event_name == 'push'
+        if: | 
+          github.event_name == 'release' || 
+          github.event_name == 'workflow_dispatch'
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -56,7 +58,9 @@ jobs:
           user_email: 41898282+github-actions[bot]@users.noreply.github.com
 
       - name: Trigger mintlify workflow
-        if: github.event_name == 'push'
+        if: | 
+          github.event_name == 'release' || 
+          github.event_name == 'workflow_dispatch'
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           github-token: ${{ secrets.DOCS_WORKFLOW_TOKEN }}
@@ -72,7 +76,9 @@ jobs:
         run: python docs-scripts/configure-redirects.py neuralforecast
 
       - name: Deploy to Github Pages
-        if: github.event_name == 'push'
+        if: | 
+          github.event_name == 'release' || 
+          github.event_name == 'workflow_dispatch'
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
To prevent many more issues like #1182, only build docs on release, not on push to main.

