### PR TITLE
[FIX] Multivariate models give error when predicting when n_series > batch_size

### DIFF
--- a/nbs/common.base_model.ipynb
+++ b/nbs/common.base_model.ipynb
@@ -341,7 +341,7 @@
     "        else:\n",
     "            self.batch_size = batch_size\n",
     "        if valid_batch_size is None:\n",
-    "            self.valid_batch_size = batch_size\n",
+    "            self.valid_batch_size = self.batch_size\n",
     "        else:\n",
     "            self.valid_batch_size = valid_batch_size\n",
     "        if inference_windows_batch_size is None:\n",

--- a/neuralforecast/common/_base_model.py
+++ b/neuralforecast/common/_base_model.py
@@ -323,7 +323,7 @@ class BaseModel(pl.LightningModule):
         else:
             self.batch_size = batch_size
         if valid_batch_size is None:
-            self.valid_batch_size = batch_size
+            self.valid_batch_size = self.batch_size
         else:
             self.valid_batch_size = valid_batch_size
         if inference_windows_batch_size is None:


### PR DESCRIPTION
Multivariate models give an error when predicting when `n_series` > `batch_size`. This was already fixed for training, but not for predicting. Subtle bug, easy fix. 

The below code fails without the fix, and runs correctly with it:

```
import pandas as pd
import matplotlib.pyplot as plt

from neuralforecast import NeuralForecast
from neuralforecast.models import TSMixerx
from neuralforecast.utils import generate_series

N_SERIES = 100
FREQ= 'D'
df = generate_series(n_series=N_SERIES, seed=0, freq=FREQ, equal_ends=True)
max_ds = df.ds.max() - pd.Timedelta(14, FREQ)
Y_TRAIN_DF = df[df.ds < max_ds]
Y_TEST_DF = df[df.ds >= max_ds]

model = TSMixerx(h=12,
                input_size=24,
                n_series=N_SERIES,
                max_steps=10,
                batch_size=10,
                revin=False,
                )

fcst = NeuralForecast(models=[model], freq=FREQ)
fcst.fit(df=Y_TRAIN_DF)
forecasts = fcst.predict(futr_df=Y_TEST_DF)
```