### PR TITLE
FIX: Remove constraint on nbdev version

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,7 +19,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install dependencies
-        run: pip install black nbdev==2.3.25 pre-commit
+        run: pip install black nbdev pre-commit
 
       - name: Run pre-commit
         run: pre-commit run --files neuralforecast/*

--- a/settings.ini
+++ b/settings.ini
@@ -18,7 +18,7 @@ status = 2
 requirements = coreforecast>=0.0.6 fsspec numpy>=1.21.6 pandas>=1.3.5 torch>=2.0.0 pytorch-lightning>=2.0.0 ray[tune]>=2.2.0 optuna utilsforecast>=0.2.3
 spark_requirements = fugue pyspark>=3.5
 aws_requirements = fsspec[s3]
-dev_requirements = black gitpython hyperopt ipython<=8.32.0 matplotlib mypy nbdev==2.3.25 polars pre-commit pyarrow ruff s3fs transformers
+dev_requirements = black gitpython hyperopt ipython<=8.32.0 matplotlib mypy nbdev polars pre-commit pyarrow ruff s3fs transformers
 nbs_path = nbs
 doc_path = _docs
 recursive = True


### PR DESCRIPTION
There was a new release of nbdev 2 days ago that comes with a fix that does not require an older version of nbdev anymore. 