### PR TITLE
FIX: Set 2.0.0<=pytorch<=2.6.0 to avoid conflicts with networkx with Python 3.9

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Install pip requirements
         run: >
           pip install uv &&
-          uv pip install --system -i https://download.pytorch.org/whl/cpu torch &&
+          uv pip install --system -i https://download.pytorch.org/whl/cpu "torch>=2.0.0,<=2.6.0" &&
           uv pip install --system "numpy<2" ".[dev]"
 
       - name: Tests

--- a/environment-cpu.yml
+++ b/environment-cpu.yml
@@ -15,7 +15,7 @@ dependencies:
   - optuna
   - pandas>=1.3.5
   - pyarrow
-  - pytorch>=2.0.0
+  - pytorch>=2.0.0,<=2.6.0
   - pytorch-lightning>=2.0.0
   - pip
   - s3fs

--- a/environment-cuda.yml
+++ b/environment-cuda.yml
@@ -15,7 +15,7 @@ dependencies:
   - optuna
   - pandas>=1.3.5
   - pyarrow
-  - pytorch>=2.0.0
+  - pytorch>=2.0.0,<=2.6.0
   - pytorch-cuda>=11.8
   - pytorch-lightning>=2.0.0
   - pip

--- a/settings.ini
+++ b/settings.ini
@@ -15,7 +15,7 @@ language = English
 custom_sidebar = True
 license = apache2
 status = 2
-requirements = coreforecast>=0.0.6 fsspec numpy>=1.21.6 pandas>=1.3.5 torch>=2.0.0 pytorch-lightning>=2.0.0 ray[tune]>=2.2.0 optuna utilsforecast>=0.2.3
+requirements = coreforecast>=0.0.6 fsspec numpy>=1.21.6 pandas>=1.3.5 torch>=2.0.0,<=2.6.0 pytorch-lightning>=2.0.0 ray[tune]>=2.2.0 optuna utilsforecast>=0.2.3
 spark_requirements = fugue pyspark>=3.5
 aws_requirements = fsspec[s3]
 dev_requirements = black fastcore<=1.7.29 gitpython hyperopt ipython<=8.32.0 matplotlib mypy nbdev==2.3.25 polars pre-commit pyarrow ruff s3fs transformers


### PR DESCRIPTION
Installing PyTorch 2.7 creates a conflict with networkx when using Python 3.9.

Fixing the version to be between 2 and 2.6 solves the problem.