### PR TITLE
FIX: Allow static vars only with NBEATSx and exogenous block

### DIFF
--- a/nbs/models.nbeatsx.ipynb
+++ b/nbs/models.nbeatsx.ipynb
@@ -3,6 +3,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "1e3afcc3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%set_env PYTORCH_ENABLE_MPS_FALLBACK=1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "524620c1",
    "metadata": {},
    "outputs": [],
@@ -282,7 +292,9 @@
     "        \"\"\" \"\"\"\n",
     "        super().__init__()\n",
     "\n",
+    "        self.h = h\n",
     "        self.dropout_prob = dropout_prob\n",
+    "        self.input_size = input_size\n",
     "        self.futr_input_size = futr_input_size\n",
     "        self.hist_input_size = hist_input_size\n",
     "        self.stat_input_size = stat_input_size\n",
@@ -356,7 +368,7 @@
     "            elif self.futr_input_size >0:\n",
     "                futr_exog = futr_exog\n",
     "            elif self.stat_input_size >0:\n",
-    "                futr_exog = stat_exog\n",
+    "                futr_exog = stat_exog.unsqueeze(1).expand(-1, self.input_size+self.h, -1)\n",
     "            else:\n",
     "                raise(ValueError(\"No stats or future exogenous. ExogenousBlock not supported.\"))    \n",
     "            backcast, forecast = self.basis(theta, futr_exog)\n",
@@ -392,7 +404,7 @@
     "    `exclude_insample_y`: bool=False, the model skips the autoregressive features y[t-input_size:t] if True.<br>\n",
     "    `n_harmonics`: int, Number of harmonic oscillations in the SeasonalityBasis [cos(i * t/n_harmonics), sin(i * t/n_harmonics)]. Note that it will only be used if 'seasonality' is in `stack_types`.<br>\n",
     "    `n_polynomials`: int, Number of polynomial terms for TrendBasis [1,t,...,t^n_poly]. Note that it will only be used if 'trend' is in `stack_types`.<br>\n",
-    "    `stack_types`: List[str], List of stack types. Subset from ['seasonality', 'trend', 'identity'].<br>\n",
+    "    `stack_types`: List[str], List of stack types. Subset from ['seasonality', 'trend', 'identity', 'exogenous'].<br>\n",
     "    `n_blocks`: List[int], Number of blocks for each stack. Note that len(n_blocks) = len(stack_types).<br>\n",
     "    `mlp_units`: List[List[int]], Structure of hidden layers for each stack type. Each internal list should contain the number of units of each hidden layer. Note that len(n_hidden) = len(stack_types).<br>\n",
     "    `dropout_prob_theta`: float, Float between (0, 1). Dropout for N-BEATS basis.<br>\n",
@@ -1075,6 +1087,8 @@
     "                dropout_prob_theta=0.5,\n",
     "                stat_exog_list=['airline1'],\n",
     "                futr_exog_list=['trend'],\n",
+    "                stack_types = [\"identity\", \"trend\", \"seasonality\", \"exogenous\"],\n",
+    "                n_blocks = [1,1,1,1],\n",
     "                max_steps=200,\n",
     "                val_check_steps=10,\n",
     "                early_stop_patience_steps=2)\n",
@@ -1102,6 +1116,14 @@
     "plt.grid()\n",
     "plt.plot()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bf05ff9a",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Currently, using static variables only and specifying an 'exogenous' stack causes an error with NBEATSx.

```python
from neuralforecast.utils import AirPassengersDF, AirPassengersPanel, AirPassengersStatic
from neuralforecast.models import NBEATSx

Y_train_df = AirPassengersPanel[AirPassengersPanel.ds<AirPassengersPanel['ds'].values[-12]]
Y_test_df = AirPassengersPanel[AirPassengersPanel.ds>=AirPassengersPanel['ds'].values[-12]].reset_index(drop=True)

model = NBEATSx(h=12, input_size=24,
                scaler_type='robust',
                dropout_prob_theta=0.5,
                stat_exog_list=['airline1'],
                stack_types = ["identity", "trend", "seasonality", "exogenous"],
                n_blocks = [1,1,1,1],
                max_steps=200,
                val_check_steps=10,
                early_stop_patience_steps=2)

nf = NeuralForecast(
    models=[model],
    freq='ME'
)
nf.fit(df=Y_train_df, static_df=AirPassengersStatic, val_size=12)
```
There are two possible solutions:
1. Remove the 'exogenous' stack when using static variables only. However, I'm not sure that the variables will be actually used in training.
2. Reshape static variables when there are not futr_exog. This is what this PR implements.