### PR TITLE
Fix: torch version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
     "numpy>=1.21.6",
     "pandas>=1.3.5",
     "torch>=2.4.0,<2.8",
-    "torchvision>=0.19.0,<0.23",
     "pytorch-lightning>=2.0.0",
     "ray[tune]>=2.2.0",
     "optuna",


### PR DESCRIPTION
Currently a clean install of neuralforecast gives an error when we import models:

```python
from neuralforecast import NeuralForecast
from neuralforecast.models import NBEATS, NHITS
from neuralforecast.utils import AirPassengersDF
```

Gives the error: `RuntimeError: operator torchvision::nms does not exist`.

This PR fixes it (tested a clean install in Google Colab)
