### PR TITLE
Fix broken Open in Colab links

### DIFF
--- a/nbs/docs/capabilities/03_exogenous_variables.ipynb
+++ b/nbs/docs/capabilities/03_exogenous_variables.ipynb
@@ -52,7 +52,7 @@
    "source": [
     "You can run these experiments using GPU with Google Colab.\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/Nixtla/neuralforecast/blob/main/nbs/examples/Exogenous_Variables.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/Nixtla/neuralforecast/blob/main/nbs/docs/capabilities/03_exogenous_variables.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {

--- a/nbs/docs/capabilities/04_hyperparameter_tuning.ipynb
+++ b/nbs/docs/capabilities/04_hyperparameter_tuning.ipynb
@@ -36,7 +36,7 @@
    "source": [
     "You can run these experiments using GPU with Google Colab.\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/Nixtla/neuralforecast/blob/main/nbs/examples/Automatic_Hyperparameter_Tuning.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/Nixtla/neuralforecast/blob/main/nbs/docs/capabilities/04_hyperparameter_tuning.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {

--- a/nbs/docs/capabilities/05_predictInsample.ipynb
+++ b/nbs/docs/capabilities/05_predictInsample.ipynb
@@ -31,7 +31,7 @@
    "source": [
     "You can run these experiments using GPU with Google Colab.\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/Nixtla/neuralforecast/blob/main/nbs/examples/PredictInsample.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/Nixtla/neuralforecast/blob/main/nbs/docs/capabilities/05_predictInsample.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {

--- a/nbs/docs/capabilities/06_save_load_models.ipynb
+++ b/nbs/docs/capabilities/06_save_load_models.ipynb
@@ -36,7 +36,7 @@
    "source": [
     "You can run these experiments using GPU with Google Colab.\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/Nixtla/neuralforecast/blob/main/nbs/examples/Save_Load_models.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/Nixtla/neuralforecast/blob/main/nbs/docs/capabilities/06_save_load_models.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {

--- a/nbs/docs/capabilities/07_time_series_scaling.ipynb
+++ b/nbs/docs/capabilities/07_time_series_scaling.ipynb
@@ -32,7 +32,7 @@
    "source": [
     "You can run these experiments using GPU with Google Colab.\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/Nixtla/neuralforecast/blob/main/nbs/examples/Time_Series_Scaling.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/Nixtla/neuralforecast/blob/main/nbs/docs/capabilities/07_time_series_scaling.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {

--- a/nbs/docs/getting-started/02_quickstart.ipynb
+++ b/nbs/docs/getting-started/02_quickstart.ipynb
@@ -24,7 +24,7 @@
    "source": [
     "You can run these experiments using GPU with Google Colab.\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/Nixtla/neuralforecast/blob/main/nbs/examples/Getting_Started.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/Nixtla/neuralforecast/blob/main/nbs/docs/getting-started/02_quickstart.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {

--- a/nbs/docs/getting-started/05_datarequirements.ipynb
+++ b/nbs/docs/getting-started/05_datarequirements.ipynb
@@ -25,7 +25,7 @@
    "source": [
     "You can run these experiments using GPU with Google Colab.\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/Nixtla/neuralforecast/blob/main/nbs/examples/Data_Format.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/Nixtla/neuralforecast/blob/main/nbs/docs/getting-started/05_datarequirements.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {

--- a/nbs/docs/tutorials/01_getting_started_complete.ipynb
+++ b/nbs/docs/tutorials/01_getting_started_complete.ipynb
@@ -58,7 +58,7 @@
    "metadata": {},
    "source": [
     "::: {.callout-tip}\n",
-    "You can use Colab to run this Notebook interactively <a href=\"https://colab.research.google.com/github/Nixtla/neuralforecast/blob/main/nbs/examples/Getting_Started_complete.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "You can use Colab to run this Notebook interactively <a href=\"https://colab.research.google.com/github/Nixtla/neuralforecast/blob/main/nbs/docs/tutorials/01_getting_started_complete.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "::: "
    ]
   },

--- a/nbs/docs/tutorials/03_uncertainty_quantification.ipynb
+++ b/nbs/docs/tutorials/03_uncertainty_quantification.ipynb
@@ -40,7 +40,7 @@
    "source": [
     "You can run these experiments using GPU with Google Colab.\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/Nixtla/neuralforecast/blob/main/nbs/examples/UncertaintyIntervals.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/Nixtla/neuralforecast/blob/main/nbs/docs/tutorials/03_uncertainty_quantification.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {

--- a/nbs/docs/tutorials/04_longhorizon_nhits.ipynb
+++ b/nbs/docs/tutorials/04_longhorizon_nhits.ipynb
@@ -29,7 +29,7 @@
    "source": [
     "You can run these experiments using GPU with Google Colab.\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/Nixtla/neuralforecast/blob/main/nbs/examples/LongHorizon_with_NHITS.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/Nixtla/neuralforecast/blob/main/nbs/docs/tutorials/04_longhorizon_nhits.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {

--- a/nbs/docs/tutorials/05_longhorizon_transformers.ipynb
+++ b/nbs/docs/tutorials/05_longhorizon_transformers.ipynb
@@ -37,7 +37,7 @@
    "source": [
     "You can run these experiments using GPU with Google Colab.\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/Nixtla/neuralforecast/blob/main/nbs/examples/LongHorizon_with_Transformers.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/Nixtla/neuralforecast/blob/main/nbs/docs/tutorials/05_longhorizon_transformers.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {

--- a/nbs/docs/tutorials/06_longhorizon_probabilistic.ipynb
+++ b/nbs/docs/tutorials/06_longhorizon_probabilistic.ipynb
@@ -28,7 +28,7 @@
    "source": [
     "You can run these experiments using GPU with Google Colab.\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/Nixtla/neuralforecast/blob/main/nbs/examples/LongHorizon_Probabilistic.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/Nixtla/neuralforecast/blob/main/nbs/docs/tutorials/06_longhorizon_probabilistic.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {

--- a/nbs/docs/tutorials/07_forecasting_tft.ipynb
+++ b/nbs/docs/tutorials/07_forecasting_tft.ipynb
@@ -27,7 +27,7 @@
    "source": [
     "You can run these experiments using GPU with Google Colab.\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/Nixtla/neuralforecast/blob/main/nbs/examples/Forecasting_TFT.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/Nixtla/neuralforecast/blob/main/nbs/docs/tutorials/07_forecasting_tft.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {

--- a/nbs/docs/tutorials/08_multivariate_tsmixer.ipynb
+++ b/nbs/docs/tutorials/08_multivariate_tsmixer.ipynb
@@ -32,7 +32,7 @@
    "source": [
     "You can run these experiments using GPU with Google Colab.\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/Nixtla/neuralforecast/blob/main/nbs/examples/LongHorizon_with_Transformers.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/Nixtla/neuralforecast/blob/main/nbs/docs/tutorials/08_multivariate_tsmixer.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {

--- a/nbs/docs/tutorials/09_hierarchical_forecasting.ipynb
+++ b/nbs/docs/tutorials/09_hierarchical_forecasting.ipynb
@@ -34,7 +34,7 @@
    "source": [
     "You can run these experiments using GPU with Google Colab.\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/Nixtla/neuralforecast/blob/main/nbs/examples/HierarchicalNetworks.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/Nixtla/neuralforecast/blob/main/nbs/docs/tutorials/09_hierarchical_forecasting.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {

--- a/nbs/docs/tutorials/11_intermittent_data.ipynb
+++ b/nbs/docs/tutorials/11_intermittent_data.ipynb
@@ -39,7 +39,7 @@
    "metadata": {},
    "source": [
     "::: {.callout-tip}\n",
-    "You can use Colab to run this Notebook interactively <a href=\"https://colab.research.google.com/github/Nixtla/neuralforecast/blob/main/nbs/examples/IntermittentData.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "You can use Colab to run this Notebook interactively <a href=\"https://colab.research.google.com/github/Nixtla/neuralforecast/blob/main/nbs/docs/tutorials/11_intermittent_data.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "::: "
    ]
   },

--- a/nbs/docs/tutorials/13_robust_forecasting.ipynb
+++ b/nbs/docs/tutorials/13_robust_forecasting.ipynb
@@ -23,7 +23,7 @@
     "\n",
     "You can run these experiments using GPU with Google Colab.\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/Nixtla/neuralforecast/blob/main/nbs/examples/Robust_Regression.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/Nixtla/neuralforecast/blob/main/nbs/docs/tutorials/13_robust_forecasting.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {

--- a/nbs/docs/tutorials/14_interpretable_decompositions.ipynb
+++ b/nbs/docs/tutorials/14_interpretable_decompositions.ipynb
@@ -23,7 +23,7 @@
     "\n",
     "You can run these experiments using GPU with Google Colab.\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/Nixtla/neuralforecast/blob/main/nbs/examples/Signal_Decomposition.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/Nixtla/neuralforecast/blob/main/nbs/docs/tutorials/14_interpretable_decompositions.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {

--- a/nbs/docs/tutorials/16_temporal_classification.ipynb
+++ b/nbs/docs/tutorials/16_temporal_classification.ipynb
@@ -25,7 +25,7 @@
     "\n",
     "You can run these experiments using GPU with Google Colab.\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/Nixtla/neuralforecast/blob/main/nbs/examples/Temporal_Classifiers.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/Nixtla/neuralforecast/blob/main/nbs/docs/tutorials/16_temporal_classification.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {

--- a/nbs/docs/tutorials/17_transfer_learning.ipynb
+++ b/nbs/docs/tutorials/17_transfer_learning.ipynb
@@ -32,7 +32,7 @@
    "source": [
     "You can run these experiments using GPU with Google Colab.\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/Nixtla/neuralforecast/blob/main/nbs/examples/Transfer_Learning.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/Nixtla/neuralforecast/blob/main/nbs/docs/tutorials/17_transfer_learning.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {

--- a/nbs/docs/use-cases/electricity_peak_forecasting.ipynb
+++ b/nbs/docs/use-cases/electricity_peak_forecasting.ipynb
@@ -51,7 +51,7 @@
    "metadata": {},
    "source": [
     ":::{.callout-tip}\n",
-    "You can use Colab to run this Notebook interactively <a href=\"https://colab.research.google.com/github/Nixtla/neuralforecast/blob/main/nbs/examples/ElectricityPeakForecasting.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "You can use Colab to run this Notebook interactively <a href=\"https://colab.research.google.com/github/Nixtla/neuralforecast/blob/main/nbs/docs/use-cases/electricity_peak_forecasting.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     ":::\n"
    ]
   },

--- a/nbs/docs/use-cases/predictive_maintenance.ipynb
+++ b/nbs/docs/use-cases/predictive_maintenance.ipynb
@@ -25,7 +25,7 @@
     "\n",
     "You can run these experiments using GPU with Google Colab.\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/Nixtla/neuralforecast/blob/main/nbs/examples/Predictive_Maintenance.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/Nixtla/neuralforecast/blob/main/nbs/docs/use-cases/predictive_maintenance.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {


### PR DESCRIPTION
- 22 "Open in Colab" embed links in notebooks are broken.
- Caused by commit 4f76f7c11250ec2d6eae28cc7c714cf0b635636a and RP #1063. 
- By the way, the link in nbs/docs/tutorials/08_multivariate_tsmixer.ipynb was pointing to "long horizon with transformers" which is wrong to begin with.
- This fix assumes a link points to the notebook itself, not to another notebook.
- This fix was done programmatically with a Python script. Happy to share if wanted.
