### PR TITLE
[FIX] Backwards compatibility with saved models breaks if "explain" attribute isn't present

### DIFF
--- a/neuralforecast/common/_base_model.py
+++ b/neuralforecast/common/_base_model.py
@@ -1306,7 +1306,7 @@ class BaseModel(pl.LightningModule):
         n_batches = int(np.ceil(n_windows / windows_batch_size))
         y_hats = []
 
-        if self.explain:
+        if hasattr(self, "explain") and self.explain:
             insample_explanations = []
             futr_exog_explanations = []
             hist_exog_explanations = []
@@ -1342,7 +1342,7 @@ class BaseModel(pl.LightningModule):
                 y_idx=y_idx,
             )
 
-            if self.explain:
+            if hasattr(self, "explain") and self.explain:
                 (
                     insample_explanation,
                     futr_exog_explanation,
@@ -1371,7 +1371,7 @@ class BaseModel(pl.LightningModule):
         y_hat = torch.cat(y_hats, dim=0)
         self.input_size = self.input_size_backup
 
-        if self.explain:
+        if hasattr(self, "explain") and self.explain:
             insample_explanations = torch.cat(insample_explanations, dim=0)
             if futr_exog_explanations:
                 futr_exog_explanations = torch.cat(futr_exog_explanations, dim=0)
@@ -1465,7 +1465,7 @@ class BaseModel(pl.LightningModule):
             y_hats = []
 
 
-            if self.explain:
+            if hasattr(self, "explain") and self.explain:
                 insample_explanations = []
                 futr_exog_explanations = []
                 hist_exog_explanations = []
@@ -1501,7 +1501,7 @@ class BaseModel(pl.LightningModule):
                     y_idx=y_idx,
                 )
 
-                if self.explain:
+                if hasattr(self, "explain") and self.explain:
                     (
                         insample_explanation,
                         futr_exog_explanation,
@@ -1529,7 +1529,7 @@ class BaseModel(pl.LightningModule):
                 y_hats.append(y_hat)
 
             y_hat = torch.cat(y_hats, dim=0)
-            if self.explain:
+            if hasattr(self, "explain") and self.explain:
                 insample_explanations = torch.cat(insample_explanations, dim=0)
                 if futr_exog_explanations:
                     futr_exog_explanations = torch.cat(futr_exog_explanations, dim=0)


### PR DESCRIPTION
Backwards compatibility with saved models breaks if "explain" attribute isn't present, so we need to check of the attribute is present everywhere.