### PR TITLE
Fixes build-docs workflow

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -20,6 +20,8 @@ on:
 jobs:
   build-docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:


### PR DESCRIPTION
Adds into build-docs.yaml: 
``` yaml
permissions:
      contents: write
```