### PR TITLE
[FIX] Models train with many exogenous features when using files

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -770,13 +770,13 @@ def test_training_with_an_iterative_dataset(setup_airplane_data):
     pred_iterative = nf.predict(df=pred_df, futr_df=futr_df)
     pred_airline2 = pred_dataframe[pred_dataframe["id"] == "Airline2"]
     np.testing.assert_allclose(
-        pred_iterative["NHITS"], pred_airline2["NHITS"], rtol=1e-2, atol=1
+        pred_iterative["NHITS"], pred_airline2["NHITS"], rtol=0, atol=1
     )
     np.testing.assert_allclose(
-        pred_iterative["AutoMLP"], pred_airline2["AutoMLP"], rtol=1e-2, atol=1
+        pred_iterative["AutoMLP"], pred_airline2["AutoMLP"], rtol=0, atol=1
     )
     np.testing.assert_allclose(
-        pred_iterative["AutoNBEATSx"], pred_airline2["AutoNBEATSx"], rtol=1e-2, atol=1
+        pred_iterative["AutoNBEATSx"], pred_airline2["AutoNBEATSx"], rtol=0, atol=1
     )
 
 


### PR DESCRIPTION
As described in #1357, if we currently pass a list of files with a high number of exogenous features, we get OOM errors. 

To fix it, I propose to truncate large datasets and "rotate" between different chunks of data such that we load reasonable amounts of data into memory and the model can see all the data given enough training steps.

Original bug was reproduced in Colab using the script below. This PR fixes the bug.

```python
# 1. Define dataset parameters
n_series = 10
n_timesteps = 100_000
n_exog = 90 # The high number of features that causes the issue
h = 24      # Forecast horizon
input_size = 96 # Lookback window

# 2. Create a large, synthetic DataFrame
print("Creating synthetic DataFrame...")
ids = [f'series_{i}' for i in range(n_series)]
df_list = []
for i, unique_id in enumerate(ids):
    # Create timestamps
    start_date = pd.to_datetime('2020-01-01')
    timestamps = pd.date_range(start=start_date, periods=n_timesteps, freq='15min')

    # Create data
    y = np.random.randn(n_timesteps)

    # Create DataFrame for this series
    series_df = pd.DataFrame({
        'ds': timestamps,
        'unique_id': unique_id,
        'y': y
    })

    # Add exogenous features
    for j in range(n_exog):
        series_df[f'exog_{j}'] = np.random.randn(n_timesteps)

    df_list.append(series_df)

Y_df = pd.concat(df_list).reset_index(drop=True)

# Ensure data types are memory-efficient
numeric_cols = Y_df.select_dtypes(include=np.number).columns
Y_df[numeric_cols] = Y_df[numeric_cols].astype(np.float32)
print("DataFrame created. Shape:", Y_df.shape)


# 3. Save as partitioned Parquet files for large-scale loading
print("Saving data to partitioned Parquet files...")
tmpdir = tempfile.TemporaryDirectory()
Y_df.to_parquet(tmpdir.name, partition_cols=['unique_id'], index=False)

files_list = [
    f"{tmpdir.name}/{d}"
    for d in os.listdir(tmpdir.name)
    if os.path.isdir(f"{tmpdir.name}/{d}") and d.startswith('unique_id=')
]
static_df = pd.DataFrame({'unique_id': ids})


# 4. Define model and NeuralForecast object
exog_list = [f'exog_{j}' for j in range(n_exog)]

# Using standard, non-intensive hyperparameters
model = TSMixerx(
    h=h,
    input_size=input_size,
    n_series=n_series,
    hist_exog_list=exog_list, # This is the key part that causes the issue
    # futr_exog_list=exog_list, # Can also be used here
    revin=True,
    scaler_type='standard',
    batch_size=32, # Using a reasonable batch size,
    max_steps=10,
)

nf = NeuralForecast(models=[model], freq='15min')

# 5. Attempt to fit the model
# This step is expected to cause a CUDA OOM error due to memory handling of exogenous variables
import traceback

try:
    print("Attempting to fit the model...")
    nf.fit(
        df=files_list,
        static_df=static_df,
        val_size=h * 10
    )
except Exception as e:
    print(f"\nTraining failed. Error: {e}")
    traceback.print_exc()

# Clean up
tmpdir.cleanup()
```