### PR TITLE
[FIX] Apply windows batch size

### DIFF
--- a/neuralforecast/common/_base_model.py
+++ b/neuralforecast/common/_base_model.py
@@ -1310,7 +1310,7 @@ class BaseModel(pl.LightningModule):
         for i in range(n_batches):
             # Create and normalize windows [Ws, L+H, C]
             w_idxs = torch.arange(
-                i * windows_batch_size, min((i + 1) * windows_batch_size, n_windows, device=windows_temporal.device)
+                i * windows_batch_size, min((i + 1) * windows_batch_size, n_windows), device=windows_temporal.device
             )
             windows = self._sample_windows(
                 windows_temporal=windows_temporal,


### PR DESCRIPTION
Applies `windows_batch_size` before permuting to avoid materializing many windows into memory and running into OOM issues. 

With this change we fix issues #1357 and #1297.

This PR also replaces #1421; that PR will not be needed and this is a simpler fix.