### PR TITLE
Fix bare except clause in _maybe_get_quantile_idx method

### DIFF
--- a/neuralforecast/common/_base_model.py
+++ b/neuralforecast/common/_base_model.py
@@ -1693,7 +1693,7 @@ class BaseModel(pl.LightningModule):
                 idx_quantile = (self.loss.quantiles == quantile).nonzero().item()
                 offset = 1 if isinstance(self.loss, DISTRIBUTION_LOSSES) else 0
                 return idx_quantile + offset
-            except:
+            except (RuntimeError, ValueError):
                 raise ValueError("Model was not trained with a median quantile.")
         return None
 


### PR DESCRIPTION
## Problem

The `_maybe_get_quantile_idx` method in `neuralforecast/common/_base_model.py` uses a bare `except:` clause, which is a Python anti-pattern that catches all exceptions including `SystemExit` and `KeyboardInterrupt`.

## Solution

Replaced the bare except with specific exception types:
```python
except (RuntimeError, ValueError):
```

This is appropriate because:
- The code calls `.nonzero().item()` which raises `RuntimeError` when the result has zero or multiple elements
- The re-raised `ValueError` suggests value-related errors are expected
- Catching specific exceptions follows PEP 8 best practices

## References

- [PEP 8: Programming Recommendations](https://peps.python.org/pep-0008/#programming-recommendations)
- PyTorch documentation for Tensor.item()

This change improves code safety and follows Python best practices without changing functionality.