### PR TITLE
fix: add XLinear to MODEL_FILENAME_DICT for save/load support

### DIFF
--- a/neuralforecast/core.py
+++ b/neuralforecast/core.py
@@ -56,6 +56,7 @@ from neuralforecast.models import (
     TSMixer,
     TSMixerx,
     VanillaTransformer,
+    XLinear,
     iTransformer,
     xLSTM,
 )
@@ -202,6 +203,8 @@ MODEL_FILENAME_DICT = {
     "autotimexer": TimeXer,
     "xlstm": xLSTM,
     "autoxlstm": xLSTM,
+    "xlinear": XLinear,
+    "autoxlinear": XLinear,
 }
 
 


### PR DESCRIPTION
## Problem
`AutoXLinear` was added in 3.1.5 but `XLinear` was not added to `MODEL_FILENAME_DICT` in `core.py`. This causes `nf.save()` to raise:

```
ValueError: Model AutoXLinear is not supported for saving.
```

The validation in `save()` checks both `model.__class__.__name__.lower()` and `model.__class__.__base__.__name__.lower()` against the dict. Since neither `autoxlinear` nor `xlinear` is present, the save fails even though training completes successfully.

## Fix
Add `"xlinear": XLinear` and `"autoxlinear": XLinear` to `MODEL_FILENAME_DICT`, along with the corresponding import.