### PR TITLE
[FIX] Skip build-docs on dependabot PRs

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -19,6 +19,7 @@ on:
 
 jobs:
   build-docs:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
`build-docs` fails because of a token permission, but `build-docs` doesn't need to run for dependabot PRs. Currently, we're forced to push an empty commit to fix it. So here, we just skip `build-docs` for dependabot PRs.