### PR TITLE
[FEAT] Can pass `run_config` with Ray

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,5 +43,6 @@ nbs/_extensions
 
 *.png
 
+.claude/
 CLAUDE.md
 .venv/

--- a/neuralforecast/auto.py
+++ b/neuralforecast/auto.py
@@ -85,6 +85,7 @@ class AutoRNN(BaseAuto):
         alias=None,
         backend="ray",
         callbacks=None,
+        run_config=None,
     ):
         # Define search space, input/output sizes
         if config is None:
@@ -106,6 +107,7 @@ class AutoRNN(BaseAuto):
             alias=alias,
             backend=backend,
             callbacks=callbacks,
+            run_config=run_config,
         )
 
     @classmethod
@@ -157,6 +159,7 @@ class AutoLSTM(BaseAuto):
         alias=None,
         backend="ray",
         callbacks=None,
+        run_config=None,
     ):
 
         # Define search space, input/output sizes
@@ -179,6 +182,7 @@ class AutoLSTM(BaseAuto):
             alias=alias,
             backend=backend,
             callbacks=callbacks,
+            run_config=run_config,
         )
 
     @classmethod
@@ -230,6 +234,7 @@ class AutoGRU(BaseAuto):
         alias=None,
         backend="ray",
         callbacks=None,
+        run_config=None,
     ):
 
         # Define search space, input/output sizes
@@ -252,6 +257,7 @@ class AutoGRU(BaseAuto):
             alias=alias,
             backend=backend,
             callbacks=callbacks,
+            run_config=run_config,
         )
 
     @classmethod
@@ -302,6 +308,7 @@ class AutoTCN(BaseAuto):
         alias=None,
         backend="ray",
         callbacks=None,
+        run_config=None,
     ):
 
         # Define search space, input/output sizes
@@ -324,6 +331,7 @@ class AutoTCN(BaseAuto):
             alias=alias,
             backend=backend,
             callbacks=callbacks,
+            run_config=run_config,
         )
 
     @classmethod
@@ -377,6 +385,7 @@ class AutoDeepAR(BaseAuto):
         alias=None,
         backend="ray",
         callbacks=None,
+        run_config=None,
     ):
 
         # Define search space, input/output sizes
@@ -399,6 +408,7 @@ class AutoDeepAR(BaseAuto):
             alias=alias,
             backend=backend,
             callbacks=callbacks,
+            run_config=run_config,
         )
 
     @classmethod
@@ -449,6 +459,7 @@ class AutoDilatedRNN(BaseAuto):
         alias=None,
         backend="ray",
         callbacks=None,
+        run_config=None,
     ):
 
         # Define search space, input/output sizes
@@ -471,6 +482,7 @@ class AutoDilatedRNN(BaseAuto):
             alias=alias,
             backend=backend,
             callbacks=callbacks,
+            run_config=run_config,
         )
 
     @classmethod
@@ -521,6 +533,7 @@ class AutoBiTCN(BaseAuto):
         alias=None,
         backend="ray",
         callbacks=None,
+        run_config=None,
     ):
 
         # Define search space, input/output sizes
@@ -543,6 +556,7 @@ class AutoBiTCN(BaseAuto):
             alias=alias,
             backend=backend,
             callbacks=callbacks,
+            run_config=run_config,
         )
 
     @classmethod
@@ -593,6 +607,7 @@ class AutoxLSTM(BaseAuto):
         alias=None,
         backend="ray",
         callbacks=None,
+        run_config=None,
     ):
 
         # Define search space, input/output sizes
@@ -615,6 +630,7 @@ class AutoxLSTM(BaseAuto):
             alias=alias,
             backend=backend,
             callbacks=callbacks,
+            run_config=run_config,
         )
 
     @classmethod
@@ -663,6 +679,7 @@ class AutoMLP(BaseAuto):
         alias=None,
         backend="ray",
         callbacks=None,
+        run_config=None,
     ):
 
         # Define search space, input/output sizes
@@ -685,6 +702,7 @@ class AutoMLP(BaseAuto):
             alias=alias,
             backend=backend,
             callbacks=callbacks,
+            run_config=run_config,
         )
 
     @classmethod
@@ -731,6 +749,7 @@ class AutoNBEATS(BaseAuto):
         alias=None,
         backend="ray",
         callbacks=None,
+        run_config=None,
     ):
 
         # Define search space, input/output sizes
@@ -753,6 +772,7 @@ class AutoNBEATS(BaseAuto):
             alias=alias,
             backend=backend,
             callbacks=callbacks,
+            run_config=run_config,
         )
 
     @classmethod
@@ -799,6 +819,7 @@ class AutoNBEATSx(BaseAuto):
         alias=None,
         backend="ray",
         callbacks=None,
+        run_config=None,
     ):
 
         # Define search space, input/output sizes
@@ -821,6 +842,7 @@ class AutoNBEATSx(BaseAuto):
             alias=alias,
             backend=backend,
             callbacks=callbacks,
+            run_config=run_config,
         )
 
     @classmethod
@@ -880,6 +902,7 @@ class AutoNHITS(BaseAuto):
         alias=None,
         backend="ray",
         callbacks=None,
+        run_config=None,
     ):
 
         # Define search space, input/output sizes
@@ -902,6 +925,7 @@ class AutoNHITS(BaseAuto):
             alias=alias,
             backend=backend,
             callbacks=callbacks,
+            run_config=run_config,
         )
 
     @classmethod
@@ -949,6 +973,7 @@ class AutoDLinear(BaseAuto):
         alias=None,
         backend="ray",
         callbacks=None,
+        run_config=None,
     ):
 
         # Define search space, input/output sizes
@@ -971,6 +996,7 @@ class AutoDLinear(BaseAuto):
             alias=alias,
             backend=backend,
             callbacks=callbacks,
+            run_config=run_config,
         )
 
     @classmethod
@@ -1017,6 +1043,7 @@ class AutoNLinear(BaseAuto):
         alias=None,
         backend="ray",
         callbacks=None,
+        run_config=None,
     ):
 
         # Define search space, input/output sizes
@@ -1039,6 +1066,7 @@ class AutoNLinear(BaseAuto):
             alias=alias,
             backend=backend,
             callbacks=callbacks,
+            run_config=run_config,
         )
 
     @classmethod
@@ -1093,6 +1121,7 @@ class AutoTiDE(BaseAuto):
         alias=None,
         backend="ray",
         callbacks=None,
+        run_config=None,
     ):
 
         # Define search space, input/output sizes
@@ -1115,6 +1144,7 @@ class AutoTiDE(BaseAuto):
             alias=alias,
             backend=backend,
             callbacks=callbacks,
+            run_config=run_config,
         )
 
     @classmethod
@@ -1164,6 +1194,7 @@ class AutoDeepNPTS(BaseAuto):
         alias=None,
         backend="ray",
         callbacks=None,
+        run_config=None,
     ):
 
         # Define search space, input/output sizes
@@ -1186,6 +1217,7 @@ class AutoDeepNPTS(BaseAuto):
             alias=alias,
             backend=backend,
             callbacks=callbacks,
+            run_config=run_config,
         )
 
     @classmethod
@@ -1235,6 +1267,7 @@ class AutoKAN(BaseAuto):
         alias=None,
         backend="ray",
         callbacks=None,
+        run_config=None,
     ):
 
         # Define search space, input/output sizes
@@ -1257,6 +1290,7 @@ class AutoKAN(BaseAuto):
             alias=alias,
             backend=backend,
             callbacks=callbacks,
+            run_config=run_config,
         )
 
     @classmethod
@@ -1305,6 +1339,7 @@ class AutoTFT(BaseAuto):
         alias=None,
         backend="ray",
         callbacks=None,
+        run_config=None,
     ):
 
         # Define search space, input/output sizes
@@ -1327,6 +1362,7 @@ class AutoTFT(BaseAuto):
             alias=alias,
             backend=backend,
             callbacks=callbacks,
+            run_config=run_config,
         )
 
     @classmethod
@@ -1375,6 +1411,7 @@ class AutoVanillaTransformer(BaseAuto):
         alias=None,
         backend="ray",
         callbacks=None,
+        run_config=None,
     ):
 
         # Define search space, input/output sizes
@@ -1397,6 +1434,7 @@ class AutoVanillaTransformer(BaseAuto):
             alias=alias,
             backend=backend,
             callbacks=callbacks,
+            run_config=run_config,
         )
 
     @classmethod
@@ -1445,6 +1483,7 @@ class AutoInformer(BaseAuto):
         alias=None,
         backend="ray",
         callbacks=None,
+        run_config=None,
     ):
 
         # Define search space, input/output sizes
@@ -1467,6 +1506,7 @@ class AutoInformer(BaseAuto):
             alias=alias,
             backend=backend,
             callbacks=callbacks,
+            run_config=run_config,
         )
 
     @classmethod
@@ -1515,6 +1555,7 @@ class AutoAutoformer(BaseAuto):
         alias=None,
         backend="ray",
         callbacks=None,
+        run_config=None,
     ):
 
         # Define search space, input/output sizes
@@ -1537,6 +1578,7 @@ class AutoAutoformer(BaseAuto):
             alias=alias,
             backend=backend,
             callbacks=callbacks,
+            run_config=run_config,
         )
 
     @classmethod
@@ -1584,6 +1626,7 @@ class AutoFEDformer(BaseAuto):
         alias=None,
         backend="ray",
         callbacks=None,
+        run_config=None,
     ):
 
         # Define search space, input/output sizes
@@ -1606,6 +1649,7 @@ class AutoFEDformer(BaseAuto):
             alias=alias,
             backend=backend,
             callbacks=callbacks,
+            run_config=run_config,
         )
 
     @classmethod
@@ -1656,6 +1700,7 @@ class AutoPatchTST(BaseAuto):
         alias=None,
         backend="ray",
         callbacks=None,
+        run_config=None,
     ):
 
         # Define search space, input/output sizes
@@ -1678,6 +1723,7 @@ class AutoPatchTST(BaseAuto):
             alias=alias,
             backend=backend,
             callbacks=callbacks,
+            run_config=run_config,
         )
 
     @classmethod
@@ -1727,6 +1773,7 @@ class AutoiTransformer(BaseAuto):
         alias=None,
         backend="ray",
         callbacks=None,
+        run_config=None,
     ):
 
         # Define search space, input/output sizes
@@ -1760,6 +1807,7 @@ class AutoiTransformer(BaseAuto):
             alias=alias,
             backend=backend,
             callbacks=callbacks,
+            run_config=run_config,
         )
 
     @classmethod
@@ -1814,6 +1862,7 @@ class AutoTimeXer(BaseAuto):
         alias=None,
         backend="ray",
         callbacks=None,
+        run_config=None,
     ):
 
         # Define search space, input/output sizes
@@ -1847,6 +1896,7 @@ class AutoTimeXer(BaseAuto):
             alias=alias,
             backend=backend,
             callbacks=callbacks,
+            run_config=run_config,
         )
 
     @classmethod
@@ -1900,6 +1950,7 @@ class AutoTimesNet(BaseAuto):
         alias=None,
         backend="ray",
         callbacks=None,
+        run_config=None,
     ):
 
         # Define search space, input/output sizes
@@ -1922,6 +1973,7 @@ class AutoTimesNet(BaseAuto):
             alias=alias,
             backend=backend,
             callbacks=callbacks,
+            run_config=run_config,
         )
 
     @classmethod
@@ -1971,6 +2023,7 @@ class AutoStemGNN(BaseAuto):
         alias=None,
         backend="ray",
         callbacks=None,
+        run_config=None,
     ):
 
         # Define search space, input/output sizes
@@ -2004,6 +2057,7 @@ class AutoStemGNN(BaseAuto):
             alias=alias,
             backend=backend,
             callbacks=callbacks,
+            run_config=run_config,
         )
 
     @classmethod
@@ -2045,6 +2099,7 @@ class AutoHINT(BaseAuto):
         alias=None,
         backend="ray",
         callbacks=None,
+        run_config=None,
     ):
 
         super(AutoHINT, self).__init__(
@@ -2063,6 +2118,7 @@ class AutoHINT(BaseAuto):
             alias=alias,
             backend=backend,
             callbacks=callbacks,
+            run_config=run_config,
         )
         if backend == "optuna":
             raise Exception("Optuna is not supported for AutoHINT.")
@@ -2133,6 +2189,7 @@ class AutoTSMixer(BaseAuto):
         alias=None,
         backend="ray",
         callbacks=None,
+        run_config=None,
     ):
 
         # Define search space, input/output sizes
@@ -2166,6 +2223,7 @@ class AutoTSMixer(BaseAuto):
             alias=alias,
             backend=backend,
             callbacks=callbacks,
+            run_config=run_config,
         )
 
     @classmethod
@@ -2221,6 +2279,7 @@ class AutoTSMixerx(BaseAuto):
         alias=None,
         backend="ray",
         callbacks=None,
+        run_config=None,
     ):
 
         # Define search space, input/output sizes
@@ -2254,6 +2313,7 @@ class AutoTSMixerx(BaseAuto):
             alias=alias,
             backend=backend,
             callbacks=callbacks,
+            run_config=run_config,
         )
 
     @classmethod
@@ -2308,6 +2368,7 @@ class AutoMLPMultivariate(BaseAuto):
         alias=None,
         backend="ray",
         callbacks=None,
+        run_config=None,
     ):
 
         # Define search space, input/output sizes
@@ -2341,6 +2402,7 @@ class AutoMLPMultivariate(BaseAuto):
             alias=alias,
             backend=backend,
             callbacks=callbacks,
+            run_config=run_config,
         )
 
     @classmethod
@@ -2395,6 +2457,7 @@ class AutoSOFTS(BaseAuto):
         alias=None,
         backend="ray",
         callbacks=None,
+        run_config=None,
     ):
 
         # Define search space, input/output sizes
@@ -2428,6 +2491,7 @@ class AutoSOFTS(BaseAuto):
             alias=alias,
             backend=backend,
             callbacks=callbacks,
+            run_config=run_config,
         )
 
     @classmethod
@@ -2483,6 +2547,7 @@ class AutoTimeMixer(BaseAuto):
         alias=None,
         backend="ray",
         callbacks=None,
+        run_config=None,
     ):
 
         # Define search space, input/output sizes
@@ -2516,6 +2581,7 @@ class AutoTimeMixer(BaseAuto):
             alias=alias,
             backend=backend,
             callbacks=callbacks,
+            run_config=run_config,
         )
 
     @classmethod
@@ -2573,6 +2639,7 @@ class AutoRMoK(BaseAuto):
         alias=None,
         backend="ray",
         callbacks=None,
+        run_config=None,
     ):
 
         # Define search space, input/output sizes
@@ -2606,6 +2673,7 @@ class AutoRMoK(BaseAuto):
             alias=alias,
             backend=backend,
             callbacks=callbacks,
+            run_config=run_config,
         )
 
     @classmethod
@@ -2660,6 +2728,7 @@ class AutoXLinear(BaseAuto):
         alias=None,
         backend="ray",
         callbacks=None,
+        run_config=None,
     ):
 
         # Define search space, input/output sizes
@@ -2693,6 +2762,7 @@ class AutoXLinear(BaseAuto):
             alias=alias,
             backend=backend,
             callbacks=callbacks,
+            run_config=run_config,
         )
 
     @classmethod

--- a/neuralforecast/common/_base_auto.py
+++ b/neuralforecast/common/_base_auto.py
@@ -64,6 +64,11 @@ class BaseAuto(pl.LightningModule):
         callbacks (list of callable): List of functions to call during the optimization process.
             ray reference: https://docs.ray.io/en/latest/tune/tutorials/tune-metrics.html
             optuna reference: https://optuna.readthedocs.io/en/stable
+        run_config (ray.air.RunConfig, optional): Ray Tune `RunConfig` forwarded to `tune.Tuner`.
+            Use this to customize Ray Tune output.
+            When provided, the user-supplied `RunConfig` is used as-is, so `callbacks`
+            and `verbose` must be set on it directly. Only used with `backend='ray'`.
+            See https://docs.ray.io/en/latest/tune/api/doc/ray.tune.RunConfig.html.
     """
 
     def __init__(
@@ -83,6 +88,7 @@ class BaseAuto(pl.LightningModule):
         alias=None,
         backend="ray",
         callbacks=None,
+        run_config=None,
     ):
         super(BaseAuto, self).__init__()
         with warnings.catch_warnings(record=False):
@@ -160,6 +166,7 @@ class BaseAuto(pl.LightningModule):
         self.alias = alias
         self.backend = backend
         self.callbacks = callbacks
+        self.run_config = run_config
 
         # Base Class attributes
         self.EXOGENOUS_FUTR = cls_model.EXOGENOUS_FUTR
@@ -244,9 +251,14 @@ class BaseAuto(pl.LightningModule):
             else None
         )
 
+        if self.run_config is not None:
+            run_config = self.run_config
+        else:
+            run_config = air.RunConfig(callbacks=self.callbacks, verbose=verbose)
+
         tuner = tune.Tuner(
             tune.with_resources(train_fn_with_parameters, device_dict),
-            run_config=air.RunConfig(callbacks=self.callbacks, verbose=verbose),
+            run_config=run_config,
             tune_config=tune.TuneConfig(
                 metric="loss",
                 mode="min",

--- a/neuralforecast/common/_base_auto.py
+++ b/neuralforecast/common/_base_auto.py
@@ -252,6 +252,11 @@ class BaseAuto(pl.LightningModule):
         )
 
         if self.run_config is not None:
+            if self.callbacks is not None:
+                warnings.warn(
+                    "`callbacks` is ignored when `run_config` is provided; "
+                    "set callbacks on the RunConfig instead.",
+                )
             run_config = self.run_config
         else:
             run_config = air.RunConfig(callbacks=self.callbacks, verbose=verbose)

--- a/tests/test_common/test_base_auto.py
+++ b/tests/test_common/test_base_auto.py
@@ -169,6 +169,33 @@ def test_ray_time_budget(setup_module):
     assert y_hat.shape[0] > 0
 
 
+def test_ray_run_config_storage_path(setup_module, tmp_path):
+    dataset, _, _ = setup_module
+    from ray import air
+
+    storage_path = tmp_path / "ray_results"
+    config = {
+        "hidden_size": tune.choice([512]),
+        "num_layers": tune.choice([3, 4]),
+        "input_size": 12,
+        "max_steps": 1,
+        "val_check_steps": 1,
+    }
+    auto = BaseAuto(
+        h=12,
+        loss=MAE(),
+        valid_loss=MSE(),
+        cls_model=MLP,
+        config=config,
+        num_samples=1,
+        cpus=1,
+        gpus=0,
+        run_config=air.RunConfig(storage_path=str(storage_path), name="nf_test"),
+    )
+    auto.fit(dataset=dataset)
+    assert (storage_path / "nf_test").is_dir()
+
+
 def test_optuna_time_budget(setup_module):
     dataset, _, _ = setup_module
     auto = BaseAuto(


### PR DESCRIPTION
Auto models with `backend=ray` can now take a `run_config` to pass different options, such as storage path.