### PR TITLE
[FEAT] Transfer learning with cross-validation

### DIFF
--- a/neuralforecast/core.py
+++ b/neuralforecast/core.py
@@ -2047,10 +2047,14 @@ class NeuralForecast:
                     "`use_fitted=True` cannot be combined with `use_init_models=True`; "
                     "`use_init_models` discards the fitted weights that `use_fitted` relies on."
                 )
-            if prediction_intervals is not None:
+            if (
+                prediction_intervals is not None
+                or getattr(self, "prediction_intervals", None) is not None
+            ):
                 raise ValueError(
                     "`use_fitted=True` is not supported with `prediction_intervals` "
-                    "(calibration requires retraining)."
+                    "(calibration requires retraining). This applies whether the "
+                    "intervals were passed here or configured during the prior `fit` call."
                 )
 
         # Recover initial model if use_init_models.

--- a/neuralforecast/core.py
+++ b/neuralforecast/core.py
@@ -497,7 +497,9 @@ class NeuralForecast:
                 `val_df` can be temporally independent (no requirement that it starts immediately after `df`).
                 Cannot be used together with `val_size`. Only supported when `df` is a pandas or polars DataFrame.
                 All series in `val_df` must have the same length.
-            use_init_models (bool, optional): Use initial model passed when NeuralForecast object was instantiated.
+            use_init_models (bool, optional): If True, discards any previously fitted weights
+                and reinitializes the models from the configs passed at `NeuralForecast(__init__)`.
+                Use this to start training from scratch. Defaults to False.
             verbose (bool): Print processing steps.
             id_col (str): Column that identifies each serie.
             time_col (str): Column that identifies each timestep, its values can be timestamps or integers.
@@ -1766,7 +1768,12 @@ class NeuralForecast:
     def _reset_models(self):
         self.models = [deepcopy(model) for model in self.models_init]
         if self._fitted:
-            print("WARNING: Deleting previously fitted models.")
+            warnings.warn(
+                "Deleting previously fitted models because `use_init_models=True` "
+                "was passed; fitted weights will be discarded and models reinitialized "
+                "from the configs given at `NeuralForecast(__init__)`.",
+                stacklevel=2,
+            )
 
     def _no_refit_cross_validation(
         self,
@@ -1776,6 +1783,7 @@ class NeuralForecast:
         step_size: int,
         val_size: Optional[int],
         test_size: int,
+        use_fitted: bool,
         verbose: bool,
         id_col: str,
         time_col: str,
@@ -1786,96 +1794,137 @@ class NeuralForecast:
         if (df is None) and not (hasattr(self, "dataset")):
             raise Exception("You must pass a DataFrame or have one stored.")
 
-        # Process and save new dataset (in self)
-        if df is not None:
-            validate_freq(df[time_col], self.freq)
-            self.dataset, self.uids, self.last_dates, self.ds = self._prepare_fit(
-                df=df,
-                static_df=static_df,
+        # When use_fitted=True we evaluate the already-fitted model on a new
+        # holdout `df` without retraining.
+        restore_fitted_state = use_fitted and df is not None
+        _snapshot: Dict[str, object] = {}
+        if restore_fitted_state:
+            _snapshot = {
+                attr: getattr(self, attr)
+                for attr in (
+                    "scalers_",
+                    "static_scalers_",
+                    "dataset",
+                    "uids",
+                    "last_dates",
+                    "ds",
+                    "id_col",
+                    "time_col",
+                    "target_col",
+                )
+            }
+
+        try:
+            # Process and save new dataset in self
+            if df is not None:
+                validate_freq(df[time_col], self.freq)
+                self.dataset, self.uids, self.last_dates, self.ds = (
+                    self._prepare_fit(
+                        df=df,
+                        static_df=static_df,
+                        id_col=id_col,
+                        time_col=time_col,
+                        target_col=target_col,
+                    )
+                )
+            else:
+                if verbose:
+                    print("Using stored dataset.")
+
+            if val_size is not None:
+                if self.dataset.min_size < (val_size + test_size):
+                    warnings.warn(
+                        "Validation and test sets are larger than the shorter time-series."
+                    )
+
+            fcsts_df = ufp.cv_times(
+                times=self.ds,
+                uids=self.uids,
+                indptr=self.dataset.indptr,
+                h=h,
+                test_size=test_size,
+                step_size=step_size,
                 id_col=id_col,
                 time_col=time_col,
-                target_col=target_col,
             )
-        else:
-            if verbose:
-                print("Using stored dataset.")
+            # the cv_times is sorted by window and then id
+            fcsts_df = ufp.sort(fcsts_df, [id_col, "cutoff", time_col])
 
-        if val_size is not None:
-            if self.dataset.min_size < (val_size + test_size):
-                warnings.warn(
-                    "Validation and test sets are larger than the shorter time-series."
+            fcsts_list: List = []
+            for model in self.models:
+                if self._add_level and (
+                    model.loss.outputsize_multiplier > 1
+                    or isinstance(model.loss, (IQLoss, HuberIQLoss))
+                ):
+                    continue
+
+                if use_fitted:
+                    _saved_model_test_size = model.get_test_size()
+                    model.set_test_size(test_size)
+                    try:
+                        model_fcsts = model.predict(
+                            self.dataset, step_size=step_size, h=h, **data_kwargs
+                        )
+                    finally:
+                        model.set_test_size(_saved_model_test_size)
+                else:
+                    model.fit(
+                        dataset=self.dataset,
+                        val_size=val_size,
+                        test_size=test_size,
+                    )
+                    model_fcsts = model.predict(
+                        self.dataset, step_size=step_size, h=h, **data_kwargs
+                    )
+                # Append predictions in memory placeholder
+                fcsts_list.append(model_fcsts)
+
+            fcsts = np.concatenate(fcsts_list, axis=-1)
+            # we may have allocated more space than needed
+            # each serie can produce at most (serie.size - 1) // self.h CV windows
+            effective_sizes = ufp.counts_by_id(fcsts_df, id_col)["counts"].to_numpy()
+            needs_trim = effective_sizes.sum() != fcsts.shape[0]
+            if self.scalers_ or needs_trim:
+                indptr = np.arange(
+                    0,
+                    n_windows * h * (self.dataset.n_groups + 1),
+                    n_windows * h,
+                    dtype=np.int32,
                 )
+                if self.scalers_:
+                    fcsts = self._scalers_target_inverse_transform(fcsts, indptr)
+                if needs_trim:
+                    # we keep only the effective samples of each serie from the cv results
+                    trimmed = np.empty_like(
+                        fcsts, shape=(effective_sizes.sum(), fcsts.shape[1])
+                    )
+                    cv_indptr = np.append(0, effective_sizes).cumsum(dtype=np.int32)
+                    for i in range(fcsts.shape[1]):
+                        ga = GroupedArray(fcsts[:, i], indptr)
+                        trimmed[:, i] = ga._tails(cv_indptr)
+                    fcsts = trimmed
 
-        fcsts_df = ufp.cv_times(
-            times=self.ds,
-            uids=self.uids,
-            indptr=self.dataset.indptr,
-            h=h,
-            test_size=test_size,
-            step_size=step_size,
-            id_col=id_col,
-            time_col=time_col,
-        )
-        # the cv_times is sorted by window and then id
-        fcsts_df = ufp.sort(fcsts_df, [id_col, "cutoff", time_col])
+            self._fitted = True
 
-        fcsts_list: List = []
-        for model in self.models:
-            if self._add_level and (
-                model.loss.outputsize_multiplier > 1
-                or isinstance(model.loss, (IQLoss, HuberIQLoss))
-            ):
-                continue
+            # Add predictions to forecasts DataFrame
+            cols = self._get_model_names(add_level=self._add_level)
+            if isinstance(self.uids, pl_Series):
+                fcsts = pl_DataFrame(dict(zip(cols, fcsts.T)))
+            else:
+                fcsts = pd.DataFrame(fcsts, columns=cols)
+            fcsts_df = ufp.horizontal_concat([fcsts_df, fcsts])
 
-            model.fit(dataset=self.dataset, val_size=val_size, test_size=test_size)
-            model_fcsts = model.predict(
-                self.dataset, step_size=step_size, h=h, **data_kwargs
+            # Add original input df's y to forecasts DataFrame
+            return ufp.join(
+                fcsts_df,
+                df[[id_col, time_col, target_col]],
+                how="left",
+                on=[id_col, time_col],
             )
-            # Append predictions in memory placeholder
-            fcsts_list.append(model_fcsts)
-
-        fcsts = np.concatenate(fcsts_list, axis=-1)
-        # we may have allocated more space than needed
-        # each serie can produce at most (serie.size - 1) // self.h CV windows
-        effective_sizes = ufp.counts_by_id(fcsts_df, id_col)["counts"].to_numpy()
-        needs_trim = effective_sizes.sum() != fcsts.shape[0]
-        if self.scalers_ or needs_trim:
-            indptr = np.arange(
-                0,
-                n_windows * h * (self.dataset.n_groups + 1),
-                n_windows * h,
-                dtype=np.int32,
-            )
-            if self.scalers_:
-                fcsts = self._scalers_target_inverse_transform(fcsts, indptr)
-            if needs_trim:
-                # we keep only the effective samples of each serie from the cv results
-                trimmed = np.empty_like(
-                    fcsts, shape=(effective_sizes.sum(), fcsts.shape[1])
-                )
-                cv_indptr = np.append(0, effective_sizes).cumsum(dtype=np.int32)
-                for i in range(fcsts.shape[1]):
-                    ga = GroupedArray(fcsts[:, i], indptr)
-                    trimmed[:, i] = ga._tails(cv_indptr)
-                fcsts = trimmed
-
-        self._fitted = True
-
-        # Add predictions to forecasts DataFrame
-        cols = self._get_model_names(add_level=self._add_level)
-        if isinstance(self.uids, pl_Series):
-            fcsts = pl_DataFrame(dict(zip(cols, fcsts.T)))
-        else:
-            fcsts = pd.DataFrame(fcsts, columns=cols)
-        fcsts_df = ufp.horizontal_concat([fcsts_df, fcsts])
-
-        # Add original input df's y to forecasts DataFrame
-        return ufp.join(
-            fcsts_df,
-            df[[id_col, time_col, target_col]],
-            how="left",
-            on=[id_col, time_col],
-        )
+        finally:
+            if restore_fitted_state:
+                for attr, value in _snapshot.items():
+                    setattr(self, attr, value)
 
     def cross_validation(
         self,
@@ -1886,6 +1935,7 @@ class NeuralForecast:
         val_size: Optional[int] = 0,
         test_size: Optional[int] = None,
         use_init_models: bool = False,
+        use_fitted: bool = False,
         verbose: bool = False,
         refit: Union[bool, int] = False,
         id_col: str = "unique_id",
@@ -1910,7 +1960,14 @@ class NeuralForecast:
             step_size (int): Step size between each window.
             val_size (int, optional): Length of validation size. If passed, set `n_windows=None`. Defaults to 0.
             test_size (int, optional): Length of test size. If passed, set `n_windows=None`.
-            use_init_models (bool, optional): Use initial model passed when object was instantiated.
+            use_init_models (bool, optional): If True, discards any previously fitted weights
+                and reinitializes the models from the configs passed at `NeuralForecast(__init__)`.
+                Use this to start cross-validation from scratch. Defaults to False.
+            use_fitted (bool, optional): Evaluate the already-fitted model on `df` without retraining
+                (transfer-learning cross-validation). Requires a previous `fit` call, `refit=False`,
+                `use_init_models=False`, and `prediction_intervals=None`. Local scalers, if any, are
+                refit per series on `df` and the fitted state (model weights, stored dataset, scalers)
+                is restored after CV completes. Defaults to False.
             verbose (bool): Print processing steps.
             refit (bool or int): Retrain model for each cross validation window.
                 If False, the models are trained at the beginning and then used to predict each window.
@@ -1976,6 +2033,26 @@ class NeuralForecast:
         assert n_windows is not None
         assert test_size is not None
 
+        if use_fitted:
+            if not self._fitted:
+                raise ValueError(
+                    "`use_fitted=True` requires a model previously fitted with `fit`."
+                )
+            if refit:
+                raise ValueError(
+                    "`use_fitted=True` is only supported with `refit=False`."
+                )
+            if use_init_models:
+                raise ValueError(
+                    "`use_fitted=True` cannot be combined with `use_init_models=True`; "
+                    "`use_init_models` discards the fitted weights that `use_fitted` relies on."
+                )
+            if prediction_intervals is not None:
+                raise ValueError(
+                    "`use_fitted=True` is not supported with `prediction_intervals` "
+                    "(calibration requires retraining)."
+                )
+
         # Recover initial model if use_init_models.
         if use_init_models:
             self._reset_models()
@@ -2003,6 +2080,7 @@ class NeuralForecast:
                 step_size=step_size,
                 val_size=val_size,
                 test_size=test_size,
+                use_fitted=use_fitted,
                 verbose=verbose,
                 id_col=id_col,
                 time_col=time_col,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -421,6 +421,166 @@ def test_local_scaler_refits_on_transfer_learning():
     )
 
 
+def test_use_init_models_emits_warning():
+    """Calling fit with use_init_models=True on an already-fitted model warns."""
+    h = 5
+    series = generate_series(3, min_length=100, max_length=100, equal_ends=True)
+    nf = NeuralForecast(
+        models=[
+            MLP(
+                input_size=2 * h,
+                h=h,
+                scaler_type=None,
+                max_steps=2,
+                val_check_steps=2,
+                enable_progress_bar=False,
+            )
+        ],
+        freq="D",
+    )
+    nf.fit(series)
+    with pytest.warns(UserWarning, match="Deleting previously fitted models"):
+        nf.fit(series, use_init_models=True)
+
+
+def test_cross_validation_use_fitted_transfer_learning():
+    """`cross_validation(use_fitted=True)` reuses fitted weights and refits scalers.
+
+    `cross_validation(refit=False)` always retrained the model on the holdout dataset, 
+    and `local_scaler_type` raised a series-count mismatch when the holdout had a different
+    number of series than the training set.
+    """
+    h = 5
+    master = generate_series(5, min_length=200, max_length=200, equal_ends=True)
+    holdout = generate_series(
+        3, min_length=200, max_length=200, equal_ends=True, seed=42
+    ).copy()
+    holdout["unique_id"] = ("h_" + holdout["unique_id"].astype(str)).astype("category")
+    holdout["y"] = holdout["y"] + 1000.0
+
+    nf = NeuralForecast(
+        models=[
+            MLP(
+                input_size=2 * h,
+                h=h,
+                scaler_type=None,
+                max_steps=5,
+                val_check_steps=5,
+                enable_progress_bar=False,
+            )
+        ],
+        freq="D",
+        local_scaler_type="standard",
+    )
+    nf.fit(master)
+
+    fitted_weights = {
+        k: v.detach().clone() for k, v in nf.models[0].state_dict().items()
+    }
+    fitted_uids = list(nf.uids)
+    fitted_scalers = nf.scalers_
+
+    cv_df = nf.cross_validation(
+        df=holdout,
+        n_windows=3,
+        step_size=1,
+        refit=False,
+        use_fitted=True,
+    )
+
+    assert set(cv_df["unique_id"].unique()) == set(holdout["unique_id"].unique())
+    assert cv_df["cutoff"].nunique() == 3
+    assert "MLP" in cv_df.columns
+    assert not cv_df["MLP"].isna().any()
+
+    for k, v in nf.models[0].state_dict().items():
+        torch.testing.assert_close(
+            fitted_weights[k],
+            v,
+            msg=lambda m, k=k: f"Weight {k} changed during use_fitted CV: {m}",
+        )
+
+    assert list(nf.uids) == fitted_uids
+    assert nf.scalers_ is fitted_scalers
+
+    master_preds = nf.predict()
+    assert set(master_preds["unique_id"].unique()) == set(master["unique_id"].unique())
+
+
+def test_cross_validation_use_fitted_restores_state_on_exception():
+    """If CV raises mid-way, fitted state must still be restored (try/finally)."""
+    h = 5
+    master = generate_series(4, min_length=120, max_length=120, equal_ends=True)
+    holdout = generate_series(
+        2, min_length=120, max_length=120, equal_ends=True, seed=7
+    ).copy()
+    holdout["unique_id"] = ("h_" + holdout["unique_id"].astype(str)).astype("category")
+
+    nf = NeuralForecast(
+        models=[
+            MLP(
+                input_size=2 * h,
+                h=h,
+                scaler_type=None,
+                max_steps=2,
+                val_check_steps=2,
+                enable_progress_bar=False,
+            )
+        ],
+        freq="D",
+        local_scaler_type="standard",
+    )
+    nf.fit(master)
+
+    fitted_uids = list(nf.uids)
+    fitted_scalers = nf.scalers_
+    fitted_dataset = nf.dataset
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("simulated failure")
+
+    nf.models[0].predict = _boom
+
+    with pytest.raises(RuntimeError, match="simulated failure"):
+        nf.cross_validation(df=holdout, n_windows=2, refit=False, use_fitted=True)
+
+    assert list(nf.uids) == fitted_uids
+    assert nf.scalers_ is fitted_scalers
+    assert nf.dataset is fitted_dataset
+
+
+def test_cross_validation_use_fitted_validation_errors():
+    """`use_fitted=True` rejects incompatible argument combinations."""
+    h = 5
+    series = generate_series(3, min_length=100, max_length=100, equal_ends=True)
+    nf = NeuralForecast(
+        models=[
+            MLP(
+                input_size=2 * h,
+                h=h,
+                scaler_type=None,
+                max_steps=2,
+                val_check_steps=2,
+                enable_progress_bar=False,
+            )
+        ],
+        freq="D",
+    )
+
+    with pytest.raises(ValueError, match="requires a model previously fitted"):
+        nf.cross_validation(df=series, n_windows=1, use_fitted=True)
+
+    nf.fit(series)
+
+    with pytest.raises(ValueError, match="only supported with `refit=False`"):
+        nf.cross_validation(df=series, n_windows=1, use_fitted=True, refit=True)
+
+    with pytest.raises(ValueError, match="cannot be combined with `use_init_models"):
+        nf.cross_validation(
+            df=series, n_windows=1, use_fitted=True, use_init_models=True
+        )
+
+
 def test_neural_forecast_boxcox_scaling(setup_airplane_data):
     """Test BoxCox scaling functionality for NeuralForecast models."""
     AirPassengersPanel_train, _ = setup_airplane_data

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -580,6 +580,22 @@ def test_cross_validation_use_fitted_validation_errors():
             df=series, n_windows=1, use_fitted=True, use_init_models=True
         )
 
+    with pytest.raises(ValueError, match="prediction_intervals"):
+        nf.cross_validation(
+            df=series,
+            n_windows=1,
+            use_fitted=True,
+            prediction_intervals=PredictionIntervals(),
+        )
+
+    # Even when the user doesn't pass prediction_intervals to cross_validation,
+    # a prior fit(prediction_intervals=...) leaves them on `self`; conformal
+    # downstream logic would still activate, so use_fitted must reject this too.
+    nf.prediction_intervals = PredictionIntervals()
+    with pytest.raises(ValueError, match="prediction_intervals"):
+        nf.cross_validation(df=series, n_windows=1, use_fitted=True)
+    nf.prediction_intervals = None
+
 
 def test_neural_forecast_boxcox_scaling(setup_airplane_data):
     """Test BoxCox scaling functionality for NeuralForecast models."""


### PR DESCRIPTION
- Adds the capability to run cross-validation with a previously fitted model (transfer learning)
- Adjusts the docstring for `use_init_models` to make it clearer