### PR TITLE
[FIX] Prevent a second optimization study when using conformal predictions

### DIFF
--- a/neuralforecast/common/_base_auto.py
+++ b/neuralforecast/common/_base_auto.py
@@ -544,7 +544,15 @@ class BaseAuto(pl.LightningModule):
         # hyperparameter selection.
         search_alg = deepcopy(self.search_alg)
         val_size = val_size if val_size > 0 else self.h
-        if self.backend == "ray":
+        # When `_reuse_search` is set (by `NeuralForecast.fit` during conformal
+        # interval calibration), refit with the previously found best config
+        reuse_search = (
+            getattr(self, "_reuse_search", False)
+            and getattr(self, "results", None) is not None
+        )
+        if reuse_search:
+            results = self.results
+        elif self.backend == "ray":
             if distributed_config is not None:
                 raise ValueError(
                     "distributed training is not supported for the ray backend."
@@ -562,7 +570,6 @@ class BaseAuto(pl.LightningModule):
                 config=self.config,
                 time_budget=self.time_budget,
             )
-            best_config = results.get_best_result().config
         else:
             results = self._optuna_tune_model(
                 cls_model=self.cls_model,
@@ -576,6 +583,10 @@ class BaseAuto(pl.LightningModule):
                 distributed_config=distributed_config,
                 time_budget=self.time_budget,
             )
+
+        if self.backend == "ray":
+            best_config = results.get_best_result().config
+        else:
             # Deepcopy so the final fit doesn't mutate the loss instances stored on
             # `self` (matches the historic behavior where optuna's `set_user_attr`
             # deepcopied the config dict).

--- a/neuralforecast/core.py
+++ b/neuralforecast/core.py
@@ -651,6 +651,14 @@ class NeuralForecast:
                     f"{train_size} timestamp(s) available for training after removing val_size."
                 )
 
+        # `_conformity_scores` (above) already ran the Auto* search and left the
+        # results on the current models. Capture them before any reset so the search
+        # can be reused for the final fit instead of rerunning on the full dataset.
+        auto_search_results = [
+            getattr(model, "results", None) if isinstance(model, BaseAuto) else None
+            for model in self.models
+        ]
+
         # Recover initial model if use_init_models
         if use_init_models:
             self._reset_models()
@@ -660,6 +668,10 @@ class NeuralForecast:
         reuse_auto_search = self._cs_df is not None
         for i, model in enumerate(self.models):
             if reuse_auto_search and isinstance(model, BaseAuto):
+                # `_reset_models` swaps in fresh clones without results; restore the
+                # captured search results so the reuse guard in BaseAuto.fit passes.
+                if auto_search_results[i] is not None:
+                    model.results = auto_search_results[i]
                 model._reuse_search = True
             try:
                 self.models[i] = model.fit(

--- a/neuralforecast/core.py
+++ b/neuralforecast/core.py
@@ -655,10 +655,19 @@ class NeuralForecast:
         if use_init_models:
             self._reset_models()
 
+        # When `_conformity_scores` has already run the Auto* search, mark the
+        # Auto* models so the search is reused instead of rerunning on the full dataset.
+        reuse_auto_search = self._cs_df is not None
         for i, model in enumerate(self.models):
-            self.models[i] = model.fit(
-                self.dataset, val_size=val_size, distributed_config=distributed_config
-            )
+            if reuse_auto_search and isinstance(model, BaseAuto):
+                model._reuse_search = True
+            try:
+                self.models[i] = model.fit(
+                    self.dataset, val_size=val_size, distributed_config=distributed_config
+                )
+            finally:
+                if isinstance(model, BaseAuto):
+                    model._reuse_search = False
 
         self._fitted = True
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2126,6 +2126,53 @@ def test_neuralforecast_conformal_prediction(setup_airplane_data, setup_airplane
     assert "uid" in preds.columns
     assert any(col.startswith(model.__name__) for col in preds.columns)
 
+def test_auto_model_prediction_intervals_runs_search_once(setup_airplane_data, monkeypatch):
+    """Auto model with prediction_intervals must not
+    re-run the hyperparameter search after `_conformity_scores` already ran it."""
+    from neuralforecast.common._base_auto import BaseAuto
+
+    AirPassengersPanel_train, _ = setup_airplane_data
+
+    def config(trial):
+        return {
+            "input_size": trial.suggest_categorical("input_size", [12]),
+            "max_steps": 1,
+            "val_check_steps": 1,
+            "hidden_size": trial.suggest_categorical("hidden_size", [8, 16]),
+        }
+
+    call_count = {"n": 0}
+    original = BaseAuto._optuna_tune_model
+
+    def counting(self, *args, **kwargs):
+        call_count["n"] += 1
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(BaseAuto, "_optuna_tune_model", counting)
+
+    nf = NeuralForecast(
+        models=[
+            AutoMLP(
+                h=12,
+                config=config,
+                num_samples=2,
+                backend="optuna",
+                search_alg=optuna.samplers.TPESampler(seed=0),
+            )
+        ],
+        freq="M",
+    )
+    nf.fit(
+        AirPassengersPanel_train,
+        prediction_intervals=PredictionIntervals(n_windows=2),
+    )
+
+    assert call_count["n"] == 1, (
+        "Optuna hyperparameter search ran "
+        f"{call_count['n']} times, expected 1 (issue #1232)"
+    )
+
+
 def test_neuralforecast_cross_validation_conformal_prediction(setup_airplane_data):
     """Test cross validation can support conformal prediction with proper refit parameter."""
     AirPassengersPanel_train, _ = setup_airplane_data

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2161,7 +2161,7 @@ def test_auto_model_prediction_intervals_runs_search_once(
             "hidden_size": tune.choice([8, 16]),
         }
         tune_method = "_tune_model"
-        auto_kwargs = dict(config=config)
+        auto_kwargs = dict(config=config, cpus=1)
 
     call_count = {"n": 0}
     original = getattr(BaseAuto, tune_method)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2126,50 +2126,66 @@ def test_neuralforecast_conformal_prediction(setup_airplane_data, setup_airplane
     assert "uid" in preds.columns
     assert any(col.startswith(model.__name__) for col in preds.columns)
 
-def test_auto_model_prediction_intervals_runs_search_once(setup_airplane_data, monkeypatch):
-    """Auto model with prediction_intervals must not
-    re-run the hyperparameter search after `_conformity_scores` already ran it."""
+@pytest.mark.parametrize("backend", ["optuna", "ray"])
+@pytest.mark.parametrize("use_init_models", [False, True])
+def test_auto_model_prediction_intervals_runs_search_once(
+    setup_airplane_data, monkeypatch, backend, use_init_models
+):
+    """Auto model with prediction_intervals must not re-run the hyperparameter search
+    after `_conformity_scores` already ran it. With `use_init_models=True`,
+    `_reset_models` swaps in fresh clones, so the captured search results must be
+    restored onto them or the search runs twice."""
     from neuralforecast.common._base_auto import BaseAuto
 
     AirPassengersPanel_train, _ = setup_airplane_data
 
-    def config(trial):
-        return {
-            "input_size": trial.suggest_categorical("input_size", [12]),
+    if backend == "optuna":
+        def config(trial):
+            return {
+                "input_size": trial.suggest_categorical("input_size", [12]),
+                "max_steps": 1,
+                "val_check_steps": 1,
+                "hidden_size": trial.suggest_categorical("hidden_size", [8, 16]),
+            }
+
+        tune_method = "_optuna_tune_model"
+        auto_kwargs = dict(
+            config=config,
+            search_alg=optuna.samplers.TPESampler(seed=0),
+        )
+    else:
+        config = {
+            "input_size": tune.choice([12]),
             "max_steps": 1,
             "val_check_steps": 1,
-            "hidden_size": trial.suggest_categorical("hidden_size", [8, 16]),
+            "hidden_size": tune.choice([8, 16]),
         }
+        tune_method = "_tune_model"
+        auto_kwargs = dict(config=config)
 
     call_count = {"n": 0}
-    original = BaseAuto._optuna_tune_model
+    original = getattr(BaseAuto, tune_method)
 
     def counting(self, *args, **kwargs):
         call_count["n"] += 1
         return original(self, *args, **kwargs)
 
-    monkeypatch.setattr(BaseAuto, "_optuna_tune_model", counting)
+    monkeypatch.setattr(BaseAuto, tune_method, counting)
 
     nf = NeuralForecast(
-        models=[
-            AutoMLP(
-                h=12,
-                config=config,
-                num_samples=2,
-                backend="optuna",
-                search_alg=optuna.samplers.TPESampler(seed=0),
-            )
-        ],
+        models=[AutoMLP(h=12, num_samples=2, backend=backend, **auto_kwargs)],
         freq="M",
     )
     nf.fit(
         AirPassengersPanel_train,
         prediction_intervals=PredictionIntervals(n_windows=2),
+        use_init_models=use_init_models,
     )
 
     assert call_count["n"] == 1, (
-        "Optuna hyperparameter search ran "
-        f"{call_count['n']} times, expected 1 (issue #1232)"
+        f"{backend} hyperparameter search ran {call_count['n']} times with "
+        f"use_init_models={use_init_models}, expected 1 (issue #1232; search results "
+        "must survive _reset_models)"
     )
 
 


### PR DESCRIPTION
Currently, Auto models with conformal predictions will fire a second optimization. This PR prevents it by reusing the optimal config to compute the prediction intervals.