### PR TITLE
[FIX] Raise error when missing params in auto config

### DIFF
--- a/neuralforecast/common/_base_auto.py
+++ b/neuralforecast/common/_base_auto.py
@@ -1,6 +1,7 @@
 __all__ = ['BaseAuto', 'RayOptions', 'OptunaOptions']
 
 
+import inspect
 import warnings
 from copy import deepcopy
 from dataclasses import dataclass, fields, replace
@@ -117,6 +118,10 @@ class BaseAuto(pl.LightningModule):
         loss (PyTorch module): Instantiated train loss class from [losses collection](./losses.pytorch.html).
         valid_loss (PyTorch module): Instantiated valid loss class from [losses collection](./losses.pytorch.html).
         config (dict or callable): Dictionary with ray.tune defined search space or function that takes an optuna trial and returns a configuration dict.
+            The config must include every parameter of the underlying model that has no
+            default value (e.g. `input_size`, and `n_series` for multivariate models),
+            either as a fixed value or as a search variable. `h`, `loss`, and `valid_loss`
+            are injected automatically and must not be set in `config`.
         search_alg (ray.tune.search variant or optuna.sampler): For ray see https://docs.ray.io/en/latest/tune/api_docs/suggestion.html
             For optuna see https://optuna.readthedocs.io/en/stable/reference/samplers/index.html.
         num_samples (int): Number of hyperparameter optimization steps/samples.
@@ -240,6 +245,29 @@ class BaseAuto(pl.LightningModule):
             self.early_stop_patience_steps = 1
         else:
             self.early_stop_patience_steps = -1
+
+        # Surface required-but-missing parameters up front. Without this,
+        auto_provided = {"h", "loss", "valid_loss"}
+        missing_required = [
+            name
+            for name, param in inspect.signature(cls_model.__init__).parameters.items()
+            if name != "self"
+            and name not in auto_provided
+            and name not in config_base
+            and param.default is inspect.Parameter.empty
+            and param.kind
+            in (
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                inspect.Parameter.KEYWORD_ONLY,
+            )
+        ]
+        if missing_required:
+            raise ValueError(
+                f"`config` is missing required parameter(s) for "
+                f"{cls_model.__name__}: {missing_required}. These parameters "
+                f"have no default and must be provided in `config` (either as "
+                f"a fixed value or as a tune/optuna search variable)."
+            )
 
         if callable(config):
             # reset config_base here to save params to override in the config fn

--- a/tests/test_common/test_base_auto.py
+++ b/tests/test_common/test_base_auto.py
@@ -7,6 +7,7 @@ import pandas as pd
 import pytest
 from ray import tune
 
+from neuralforecast.auto import AutoMLP
 from neuralforecast.common._base_auto import BaseAuto, OptunaOptions, RayOptions
 from neuralforecast.losses.pytorch import MAE, MSE
 from neuralforecast.models.mlp import MLP
@@ -139,6 +140,30 @@ def test_validation_default(setup_config):
     )
     assert str(type(auto.loss)) == "<class 'neuralforecast.losses.pytorch.MSE'>"
     assert str(type(auto.valid_loss)) == "<class 'neuralforecast.losses.pytorch.MSE'>"
+
+
+def test_config_missing_required_param_raises():
+    # A config that omits a required no-default arg of the underlying model used to fail deep
+    # inside ray with an opaque "No best trial found" error. Now it must fail fast
+    # at construction time with a message naming the missing key.
+    with pytest.raises(ValueError, match="input_size"):
+        AutoMLP(
+            h=4,
+            config={
+                "max_steps": tune.choice([5]),
+                "random_seed": tune.choice([0]),
+            },
+            backend="ray",
+        )
+
+    def config_fn(trial):
+        return {
+            "max_steps": trial.suggest_categorical("max_steps", [5]),
+            "random_seed": trial.suggest_categorical("random_seed", [0]),
+        }
+
+    with pytest.raises(ValueError, match="input_size"):
+        AutoMLP(h=4, config=config_fn, backend="optuna")
 
 
 def test_ray_time_budget(setup_module):


### PR DESCRIPTION
Currently, if a config for an auto model has a missing required parameter, it raises only an error when it reaches the hyperopt functions. Now, we raise an error immediately at construction.