### PR TITLE
[FIX] Early stopping with `PredictionIntervals`

### DIFF
--- a/neuralforecast/core.py
+++ b/neuralforecast/core.py
@@ -553,12 +553,23 @@ class NeuralForecast:
             )
             if prediction_intervals is not None:
                 self.prediction_intervals = prediction_intervals
+                # Conformal calibration retrains the models via cross-validation.
+                # Forward the same validation size used for the final fit.
+                conformal_val_size = val_size or 0
+                if val_df is not None:
+                    conformal_val_size = self.dataset.align(
+                        val_df,
+                        id_col=id_col,
+                        time_col=time_col,
+                        target_col=target_col,
+                    ).min_size
                 self._cs_df = self._conformity_scores(
                     df=df,
                     id_col=id_col,
                     time_col=time_col,
                     target_col=target_col,
                     static_df=static_df,
+                    val_size=conformal_val_size,
                 )
 
         elif isinstance(df, SparkDataFrame):
@@ -2602,6 +2613,7 @@ class NeuralForecast:
         time_col: str,
         target_col: str,
         static_df: Optional[DataFrame],
+        val_size: int = 0,
     ) -> DataFrame:
         """Compute conformity scores.
 
@@ -2616,6 +2628,8 @@ class NeuralForecast:
             time_col (str): Column that identifies each timestep.
             target_col (str): Column that contains the target.
             static_df (Optional[DataFrame]): DataFrame with static exogenous variables.
+            val_size (int): Validation size used to retrain the models during
+                calibration, mirroring the validation size of the final fit.
         """
         if self.prediction_intervals is None:
             raise AttributeError(
@@ -2624,12 +2638,15 @@ class NeuralForecast:
 
         min_size = ufp.counts_by_id(df, id_col)["counts"].min()
         step_size = self.prediction_intervals.step_size
-        min_samples = self.h + step_size * (self.prediction_intervals.n_windows - 1) + 1
+        min_samples = (
+            self.h + step_size * (self.prediction_intervals.n_windows - 1) + 1 + val_size
+        )
         if min_size < min_samples:
             raise ValueError(
                 "Minimum required samples in each serie for the prediction intervals "
                 f"settings are: {min_samples}, shortest serie has: {min_size}. "
-                "Please reduce the number of windows, horizon or remove those series."
+                "Please reduce the number of windows, horizon, validation size or "
+                "remove those series."
             )
 
         self._add_level = True
@@ -2638,6 +2655,7 @@ class NeuralForecast:
             static_df=static_df,
             n_windows=self.prediction_intervals.n_windows,
             step_size=step_size,
+            val_size=val_size,
             id_col=id_col,
             time_col=time_col,
             target_col=target_col,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -171,6 +171,29 @@ def test_neural_forecast_val_monitor_invalid():
         )
 
 
+# Conformal calibration retrains the models via cross-validation; it must forward
+# the same val_size as the main fit so early stopping doesn't crash.
+def test_prediction_intervals_with_early_stopping(setup_airplane_data):
+    AirPassengersPanel_train, _ = setup_airplane_data
+    model = NHITS(
+        h=12,
+        input_size=12,
+        max_steps=2,
+        val_check_steps=1,
+        early_stop_patience_steps=2,
+        val_monitor="ptl/val_loss",
+    )
+    nf = NeuralForecast(models=[model], freq="ME")
+    nf.fit(
+        AirPassengersPanel_train,
+        val_size=12,
+        prediction_intervals=PredictionIntervals(n_windows=2),
+    )
+    preds = nf.predict(level=[80])
+    assert "NHITS-lo-80" in preds.columns
+    assert "NHITS-hi-80" in preds.columns
+
+
 # test that fit raises ValueError when series are too short for input_size + h
 def test_fit_raises_on_short_series():
     # 10 timestamps, h=12, input_size=24 → train_size=10 < 24


### PR DESCRIPTION
Currently, if we pass a `val_size` with `PredictionIntervals` it errors with:
```
RuntimeError: Early stopping conditioned on metric `ptl/val_loss` which is not available.
Pass in or modify your `EarlyStopping` callback to use any of the following:
`train_loss`, `train_loss_step`, `train_loss_epoch`
```
That's because `val_size` is not wired into the cross-validation procedure used to calibrate the intervals.

This PR passes `val_size` to `_conformity_scores`, such that calibration reflects how the model is trained and no error is obtained.

Without this fix, the following fails:
```python
from neuralforecast.losses.pytorch import *
from neuralforecast.core import NeuralForecast
from neuralforecast.models import *
from neuralforecast.utils import PredictionIntervals
from neuralforecast.utils import AirPassengersPanel, AirPassengersStatic

Y_train_df = AirPassengersPanel[AirPassengersPanel['ds'] < AirPassengersPanel['ds'].values[-12]].reset_index(drop=True)
Y_test_df = AirPassengersPanel[AirPassengersPanel['ds'] >= AirPassengersPanel['ds'].values[-12]].reset_index(drop=True)
futr_df = Y_test_df.drop(columns=["y", "y_[lag12]"])

monitors = ["ptl/val_loss", "valid_loss", "train_loss"]

for monitor in monitors:
    model = MLP(h=12, input_size=24,
                stat_exog_list=['airline1'],
                futr_exog_list=['trend'], 
                hist_exog_list=["y_[lag12]"],
                val_monitor=monitor,
                scaler_type='robust',
                learning_rate=1e-3,
                max_steps=100,
                val_check_steps=10,
                early_stop_patience_steps=2,
                )

    fcst = NeuralForecast(
        models=[model],
        freq='ME'
    )
    fcst.fit(
        df=Y_train_df, 
        static_df=AirPassengersStatic, 
        val_size=12,
        prediction_intervals = PredictionIntervals(n_windows=4)
    )
 ```