### PR TITLE
Fail fast when multivariate models are configured with multiple devices

### DIFF
--- a/neuralforecast/common/_base_model.py
+++ b/neuralforecast/common/_base_model.py
@@ -87,6 +87,57 @@ def tensor_to_numpy(tensor: torch.Tensor) -> np.ndarray:
     return tensor.numpy()
 
 
+def _num_requested_devices(trainer_kwargs: dict) -> int:
+    """Best-effort count of the devices a ``pl.Trainer`` built from
+    ``trainer_kwargs`` would use. Returns 1 when the count cannot be
+    determined."""
+    devices = trainer_kwargs.get("devices")
+    if devices is None:
+        return 1
+    if isinstance(devices, (list, tuple)):
+        return len(devices)
+    if isinstance(devices, str):
+        if devices.strip() == "auto":
+            devices = -1
+        else:
+            try:
+                devices = int(devices)
+            except ValueError:
+                return 1
+    if devices == -1:
+        # all devices of the accelerator. only CUDA can resolve to more than
+        # one device here, MPS is single-device and Lightning's CPU
+        # accelerator defaults to a single process.
+        accelerator = trainer_kwargs.get("accelerator")
+        if accelerator in (None, "auto", "gpu", "cuda"):
+            return max(torch.cuda.device_count(), 1)
+        return 1
+    return int(devices)
+
+
+def _check_multivariate_single_device(model_name: str, num_devices: int) -> None:
+    """Raise an informative error when a multivariate model is configured to
+    run on more than one device.
+
+    Lightning's data-parallel strategies (DDP and friends) split each batch
+    across devices, but multivariate models require every batch to contain all
+    series, so multi-device training crashes with cryptic tensor-shape errors
+    (https://github.com/Nixtla/neuralforecast/issues/1100). Fail fast with an
+    actionable message instead."""
+    if num_devices > 1:
+        raise ValueError(
+            f"{model_name} is a multivariate model, which requires all series to be "
+            f"present in every batch, but it was configured to run on {num_devices} devices "
+            "and data-parallel strategies split each batch across devices. "
+            "This is not supported and crashes with tensor-shape errors "
+            "(see https://github.com/Nixtla/neuralforecast/issues/1100). "
+            "Single-device execution is the supported configuration for multivariate models: "
+            f"please pass devices=1 (e.g. {model_name}(..., devices=1), or "
+            "trainer_kwargs={'devices': 1} in the config of Auto models) "
+            "or devices=[DEVICE_ID] to select a specific GPU."
+        )
+
+
 class BaseModel(pl.LightningModule):
     EXOGENOUS_FUTR = True  # If the model can handle future exogenous variables
     EXOGENOUS_HIST = True  # If the model can handle historical exogenous variables
@@ -321,6 +372,15 @@ class BaseModel(pl.LightningModule):
             if torch.cuda.is_available():
                 trainer_kwargs["devices"] = -1
 
+        # Multivariate models require all series in every batch, which is
+        # incompatible with multi-device data-parallel training (#1100).
+        if self.MULTIVARIATE:
+            num_nodes = trainer_kwargs.get("num_nodes") or 1
+            _check_multivariate_single_device(
+                type(self).__name__,
+                _num_requested_devices(trainer_kwargs) * num_nodes,
+            )
+
         # Avoid saturating local memory, disabled fit model checkpoints
         if trainer_kwargs.get("enable_checkpointing", None) is None:
             trainer_kwargs["enable_checkpointing"] = False
@@ -497,6 +557,11 @@ class BaseModel(pl.LightningModule):
         test_size,
     ):
         assert distributed_config is not None
+        if self.MULTIVARIATE:
+            _check_multivariate_single_device(
+                type(self).__name__,
+                distributed_config.num_nodes * distributed_config.devices,
+            )
         from pyspark.ml.torch.distributor import TorchDistributor
 
         def train_fn(

--- a/tests/test_common/test_base_model.py
+++ b/tests/test_common/test_base_model.py
@@ -1,0 +1,75 @@
+import pytest
+
+from neuralforecast.common._base_model import _num_requested_devices
+from neuralforecast.models import MLP, NHITS, SOFTS, MLPMultivariate, TSMixer
+
+MULTIVARIATE_MODELS = [TSMixer, MLPMultivariate, SOFTS]
+UNIVARIATE_MODELS = [NHITS, MLP]
+GUARD_MATCH = "Single-device execution is the supported configuration"
+
+
+def _model_kwargs(model_cls):
+    kwargs = {"h": 2, "input_size": 4, "max_steps": 1}
+    if model_cls in MULTIVARIATE_MODELS:
+        kwargs["n_series"] = 3
+    return kwargs
+
+
+class TestMultivariateMultiDeviceGuard:
+    """Multivariate models require all series in every batch, so data-parallel
+    multi-device training is not supported and must fail fast (issue #1100)."""
+
+    @pytest.mark.parametrize("model_cls", MULTIVARIATE_MODELS)
+    @pytest.mark.parametrize("devices", [2, [0, 1], "2"], ids=["int", "list", "str"])
+    def test_multivariate_with_multiple_devices_raises(self, model_cls, devices):
+        with pytest.raises(ValueError, match=GUARD_MATCH):
+            model_cls(**_model_kwargs(model_cls), accelerator="cpu", devices=devices)
+
+    @pytest.mark.parametrize("model_cls", MULTIVARIATE_MODELS)
+    def test_multivariate_with_multiple_nodes_raises(self, model_cls):
+        with pytest.raises(ValueError, match=GUARD_MATCH):
+            model_cls(
+                **_model_kwargs(model_cls),
+                accelerator="cpu",
+                devices=1,
+                num_nodes=2,
+            )
+
+    @pytest.mark.parametrize("model_cls", MULTIVARIATE_MODELS)
+    @pytest.mark.parametrize("devices", [None, 1, [0]], ids=["default", "int", "list"])
+    def test_multivariate_with_single_device_is_allowed(self, model_cls, devices):
+        kwargs = _model_kwargs(model_cls)
+        if devices is not None:
+            kwargs.update(accelerator="cpu", devices=devices)
+        model_cls(**kwargs)
+
+    @pytest.mark.parametrize("model_cls", UNIVARIATE_MODELS)
+    def test_univariate_with_multiple_devices_is_allowed(self, model_cls):
+        model_cls(**_model_kwargs(model_cls), accelerator="cpu", devices=2)
+
+    def test_error_message_is_actionable(self):
+        with pytest.raises(ValueError) as exc_info:
+            TSMixer(**_model_kwargs(TSMixer), accelerator="cpu", devices=2)
+        message = str(exc_info.value)
+        assert "TSMixer" in message
+        assert "all series" in message
+        assert "devices=1" in message
+        assert "issues/1100" in message
+
+
+@pytest.mark.parametrize(
+    "trainer_kwargs, expected",
+    [
+        ({}, 1),
+        ({"devices": None}, 1),
+        ({"devices": 1}, 1),
+        ({"devices": 4}, 4),
+        ({"devices": [0, 1]}, 2),
+        ({"devices": "2"}, 2),
+        ({"devices": "auto", "accelerator": "cpu"}, 1),
+        ({"devices": -1, "accelerator": "cpu"}, 1),
+        ({"devices": "bogus"}, 1),
+    ],
+)
+def test_num_requested_devices(trainer_kwargs, expected):
+    assert _num_requested_devices(trainer_kwargs) == expected


### PR DESCRIPTION
Addresses #1100 (and the duplicate reports in #1291, #1037 and #686).

## What

Multivariate models currently crash with cryptic tensor-shape `RuntimeError`s deep inside training when configured with more than one device — because data-parallel strategies split each batch across devices, while multivariate models require all series to be present in every batch (as @jmoralez diagnosed in #1100).

This PR makes that failure mode explicit: model construction (and the Spark `_fit_distributed` path) now raises a clear `ValueError` when a multivariate model is configured with multiple devices, telling the user exactly why and how to fix it (`devices=1`, or `trainer_kwargs={'devices': 1}` for Auto models). `predict` already self-protected by forcing a single device; `fit` was the unguarded path.

Full multi-GPU support for multivariate models would be the real resolution of #1100 and remains future work — this PR turns an opaque crash into a documented limitation in the meantime.

## Note on SOFTS

The issue title says "except SOFTS", but the thread only establishes that SOFTS *doesn't crash* — under batch-splitting it would still compute cross-series interactions over an incomplete subset of series, which is silent incorrectness rather than support. Since SOFTS declares `MULTIVARIATE = True`, it is guarded too. Happy to exempt it if maintainers prefer.

## Details

- `_num_requested_devices()` handles the device-spec forms (`int`, `-1`, list, `"auto"`, numeric strings) and multiplies by `num_nodes`
- The check runs at `BaseModel.__init__` right after accelerator/devices resolution — before any `Trainer` exists, so it fires immediately and needs no GPU
- New CPU-only tests (33) parametrized over TSMixer / MLPMultivariate / SOFTS × device specs, with univariate models as negative controls; tests fail without the source change
- `tests/test_common/` plus the multivariate model test files: 127 passed, no regressions; pre-commit (ruff, mypy) clean