### PR TITLE
[FIX] Multi-device training for multivariate models

### DIFF
--- a/neuralforecast/common/_base_model.py
+++ b/neuralforecast/common/_base_model.py
@@ -321,6 +321,11 @@ class BaseModel(pl.LightningModule):
             if torch.cuda.is_available():
                 trainer_kwargs["devices"] = -1
 
+        # Multivariate models require every batch to contain all series, so the
+        # data-parallel axis must be the time-windows, not the series.
+        if self.MULTIVARIATE:
+            trainer_kwargs.setdefault("use_distributed_sampler", False)
+
         # Avoid saturating local memory, disabled fit model checkpoints
         if trainer_kwargs.get("enable_checkpointing", None) is None:
             trainer_kwargs["enable_checkpointing"] = False
@@ -931,6 +936,24 @@ class BaseModel(pl.LightningModule):
         y_hat = self.scaler.inverse_transform(z=y_hat, x_scale=y_scale, x_shift=y_loc)
 
         return y_hat
+
+    def _shard_multivariate_windows(self, final_condition):
+        """Assign each device a disjoint slice of the valid time-windows.
+
+        Multivariate models keep all series in every batch. Striding the
+        valid windows by `global_rank` gives data parallelism over the
+        window axis, with DDP averaging the per-device gradients.
+
+        Falls back to no sharding when there are fewer valid windows than
+        devices, so no rank is left with an empty batch. All ranks observe the
+        same batch.
+        """
+        if not self.MULTIVARIATE or self._trainer is None:
+            return final_condition
+        world_size = self.trainer.world_size
+        if world_size <= 1 or len(final_condition) < world_size:
+            return final_condition
+        return final_condition[self.global_rank :: world_size]
 
     def _sample_windows(
         self,
@@ -1773,6 +1796,7 @@ class BaseModel(pl.LightningModule):
         windows_temporal, static, static_cols, final_condition, sample_weight_windows, temporal_cols = (
             self._create_windows(batch, step="train")
         )
+        final_condition = self._shard_multivariate_windows(final_condition)
         n_windows = len(final_condition)
         if self.windows_batch_size is not None:
             if n_windows < self.windows_batch_size:

--- a/tests/test_common/test_multi_device_training.py
+++ b/tests/test_common/test_multi_device_training.py
@@ -1,0 +1,101 @@
+"""Regression tests for multi-device training of multivariate models (#1100).
+
+Multivariate models need all series in every batch, so we shard the
+time-windows across devices instead of the series.
+"""
+import types
+
+import numpy as np
+import pandas as pd
+import pytest
+import torch
+
+from neuralforecast import NeuralForecast
+from neuralforecast.losses.pytorch import MAE
+from neuralforecast.models import NHITS, SOFTS, MLPMultivariate, TSMixer
+
+MULTIVARIATE_MODELS = [TSMixer, MLPMultivariate, SOFTS]
+
+
+def _model_kwargs(model_cls, **overrides):
+    kwargs = {"h": 2, "input_size": 4, "max_steps": 1}
+    if model_cls in MULTIVARIATE_MODELS:
+        kwargs["n_series"] = 3
+    kwargs.update(overrides)
+    return kwargs
+
+
+def _fake_trainer(world_size, global_rank):
+    return types.SimpleNamespace(world_size=world_size, global_rank=global_rank)
+
+
+class TestShardMultivariateWindows:
+    def test_windows_are_partitioned_disjointly_across_ranks(self):
+        fc = torch.arange(10)
+        shards = []
+        for rank in range(3):
+            model = TSMixer(**_model_kwargs(TSMixer))
+            model._trainer = _fake_trainer(world_size=3, global_rank=rank)
+            shards.append(model._shard_multivariate_windows(fc))
+        # every window assigned exactly once, no overlap
+        assert torch.equal(torch.cat(shards).sort().values, fc)
+        assert sum(len(s) for s in shards) == len(fc)
+
+    def test_fallback_when_fewer_windows_than_devices(self):
+        # No rank may end up with an empty batch (would deadlock DDP).
+        model = TSMixer(**_model_kwargs(TSMixer))
+        model._trainer = _fake_trainer(world_size=4, global_rank=2)
+        fc = torch.arange(3)
+        assert torch.equal(model._shard_multivariate_windows(fc), fc)
+
+    @pytest.mark.parametrize(
+        "model_cls, trainer",
+        [
+            (TSMixer, None),  # no trainer attached
+            (TSMixer, _fake_trainer(world_size=1, global_rank=0)),  # single device
+            (NHITS, _fake_trainer(world_size=2, global_rank=1)),  # univariate
+        ],
+    )
+    def test_returns_all_windows_when_sharding_not_applicable(self, model_cls, trainer):
+        model = model_cls(**_model_kwargs(model_cls))
+        if trainer is not None:
+            model._trainer = trainer
+        fc = torch.arange(10)
+        assert torch.equal(model._shard_multivariate_windows(fc), fc)
+
+
+def _make_df(n_series=4, length=60):
+    rng = np.random.default_rng(0)
+    dates = pd.date_range("2020-01-01", periods=length, freq="15min")
+    return pd.concat(
+        [
+            pd.DataFrame(
+                {"unique_id": f"s{i}", "ds": dates, "y": rng.standard_normal(length).cumsum()}
+            )
+            for i in range(n_series)
+        ],
+        ignore_index=True,
+    )
+
+
+@pytest.mark.parametrize("model_cls", MULTIVARIATE_MODELS)
+def test_multivariate_trains_on_multi_process_ddp(model_cls):
+    """Multivariate models train on >1 device without crashing.
+
+    CPU multi-process DDP (gloo) reproduces the same batch-sharding as
+    multi-GPU, so no GPU is required.
+    """
+    if not torch.distributed.is_gloo_available():
+        pytest.skip("gloo backend required for CPU DDP")
+    df = _make_df()
+    n_series = df["unique_id"].nunique()
+    model = model_cls(
+        **_model_kwargs(model_cls, n_series=n_series, max_steps=2),
+        batch_size=n_series,
+        loss=MAE(),
+        accelerator="cpu",
+        devices=2,
+        strategy="ddp_spawn",
+    )
+    nf = NeuralForecast(models=[model], freq="15min")
+    nf.fit(df=df)


### PR DESCRIPTION
**Root cause**
For multivariate models, each dataset item is a whole series, so one batch contains all `n_series` and the windows are reshaped to `[Ws, L+h, C, n_series]`.
But the standard fit path builds the Trainer without `use_distributed_sampler=False`, so on more than one device Lightning injects a `DistributedSampler` that shards the series across devices. Each device then receives only `n_series / world_size` series, the `n_series` axis no longer matches the weights, and training crashes.

**Solution**
Multivariate models parallelize over time-windows, not series, so:

1. Keep all series on every device so the default is  `use_distributed_sampler=False` for multivariate models (the Spark _fit_distributed path already does this)
2. Shard the windows by rank with a fallback to no sharding when there are fewer windows than devices. DDP averages the per-device gradients.