### PR TITLE
feat: add torchembed optional temporal embedding backend for transformer models

### DIFF
--- a/neuralforecast/common/_modules.py
+++ b/neuralforecast/common/_modules.py
@@ -4,6 +4,7 @@
 __all__ = ['ACTIVATIONS', 'MLP', 'Chomp1d', 'CausalConv1d', 'TemporalConvolutionEncoder', 'TransEncoderLayer', 'TransEncoder',
            'TransDecoderLayer', 'TransDecoder', 'AttentionLayer', 'TriangularCausalMask', 'FullAttention',
            'PositionalEmbedding', 'TokenEmbedding', 'TimeFeatureEmbedding', 'FixedEmbedding', 'TemporalEmbedding',
+           'TorchembedTemporalEmbedding',
            'DataEmbedding', 'DataEmbedding_inverted', 'MovingAvg', 'SeriesDecomp', 'RevIN', 'RevINMultivariate']
 
 
@@ -829,7 +830,100 @@ class TimeFeatureEmbedding(nn.Module):
         return self.embed(x)
 
 
-class FixedEmbedding(nn.Module):  
+class TorchembedTemporalEmbedding(nn.Module):
+    """Temporal embedding powered by torchembed's composable cyclic encoders.
+
+    Replaces the plain linear ``TimeFeatureEmbedding`` with properly periodic
+    (sin, cos) encodings for each exogenous feature, then projects the
+    concatenated 2D cyclic vectors to the model's hidden dimension.
+
+    Each feature column in *x_mark* is treated as a periodic signal.
+    ``CyclicEmbedding(period=p)`` maps a normalised scalar in [0, 1] to
+    ``(sin(2π·x/p), cos(2π·x/p))``, yielding a 2-D representation that is
+    equivariant under cyclic shifts and avoids the discontinuity at the wrap
+    boundary.
+
+    If *periods* is ``None`` the class infers sensible defaults from the number
+    of features following the Informer/Autoformer convention of
+    (month, day, weekday, hour[, minute]).  Callers may pass an explicit list
+    of periods — one per feature column — for full control.
+
+    Args:
+        input_size (int): Number of exogenous feature columns in *x_mark*.
+        hidden_size (int): Dimension of the output embeddings (model's d_model).
+        periods (list[float] | None): Cyclic period for each feature.
+            Defaults to ``None``, which uses the Informer convention
+            ``[12, 31, 7, 24, 60]`` truncated / extended to *input_size*.
+
+    Input:
+        x_mark (torch.Tensor): shape ``[batch, seq_len, input_size]``, values
+            already in their natural range (e.g. 0–23 for hour-of-day).
+
+    Returns:
+        torch.Tensor: shape ``[batch, seq_len, hidden_size]``.
+
+    Notes:
+        - Requires ``torchembed >= 0.3.1``  (``pip install torchembed``).
+        - Falls back with a clear ``ImportError`` when torchembed is absent so
+          models remain importable; the error surfaces only when the embedding
+          is instantiated.
+        - The projection layer is initialised with Kaiming uniform to match the
+          weight init convention used elsewhere in this module.
+    """
+
+    # Default periods following the Informer/Autoformer calendar convention:
+    # [month(1-12), day(1-31), weekday(0-6), hour(0-23), minute(0-59)]
+    _DEFAULT_PERIODS = [12.0, 31.0, 7.0, 24.0, 60.0]
+
+    def __init__(
+        self,
+        input_size: int,
+        hidden_size: int,
+        periods=None,
+    ):
+        super(TorchembedTemporalEmbedding, self).__init__()
+
+        try:
+            from torchembed.temporal import CyclicEmbedding  # noqa: F401
+        except ImportError as exc:
+            raise ImportError(
+                "torchembed is required for temporal_embedding='torchembed'. "
+                "Install it with:  pip install 'neuralforecast[torchembed]'  "
+                "or  pip install torchembed>=0.3.1"
+            ) from exc
+
+        from torchembed.temporal import CyclicEmbedding
+
+        if periods is None:
+            periods = (self._DEFAULT_PERIODS * ((input_size // 5) + 1))[:input_size]
+
+        if len(periods) != input_size:
+            raise ValueError(
+                f"len(periods)={len(periods)} must equal input_size={input_size}"
+            )
+
+        self.cyclic_encoders = nn.ModuleList(
+            [CyclicEmbedding(period=float(p)) for p in periods]
+        )
+        # Project from 2*input_size (stacked sin/cos pairs) to hidden_size
+        self.proj = nn.Linear(2 * input_size, hidden_size, bias=False)
+        nn.init.kaiming_uniform_(self.proj.weight, nonlinearity="linear")
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # x: [batch, seq_len, input_size]
+        cyclic_parts = []
+        for i, encoder in enumerate(self.cyclic_encoders):
+            # encoder expects (batch,) or (batch, seq_len); we flatten then restore
+            feat = x[..., i]  # [batch, seq_len]
+            B, T = feat.shape
+            encoded = encoder(feat.reshape(-1))  # [B*T, 2]
+            cyclic_parts.append(encoded.view(B, T, 2))
+        # Concatenate along last dim: [batch, seq_len, 2*input_size]
+        out = torch.cat(cyclic_parts, dim=-1)
+        return self.proj(out)  # [batch, seq_len, hidden_size]
+
+
+class FixedEmbedding(nn.Module):
     """Fixed sinusoidal embedding for categorical temporal features.  
 
     Creates non-trainable embeddings using sine and cosine functions at different  
@@ -932,21 +1026,31 @@ class TemporalEmbedding(nn.Module):
         return hour_x + weekday_x + day_x + month_x + minute_x
 
 
-class DataEmbedding(nn.Module):  
-    """Data embedding module combining value, positional, and temporal embeddings.  
+class DataEmbedding(nn.Module):
+    """Data embedding module combining value, positional, and temporal embeddings.
 
-    Transforms time series data into high-dimensional embeddings by combining:  
-    - Value embeddings: Convolutional encoding of the time series values  
-    - Positional embeddings: Sinusoidal encodings for relative position within window  
-    - Temporal embeddings: Linear projection of absolute calendar features (optional)  
+    Transforms time series data into high-dimensional embeddings by combining:
+    - Value embeddings: Convolutional encoding of the time series values
+    - Positional embeddings: Sinusoidal encodings for relative position within window
+    - Temporal embeddings: Encoding of absolute calendar features (optional)
 
-    Args:  
-        c_in (int): Number of input channels (variates) in the time series.  
-        exog_input_size (int): Number of exogenous/temporal features. If 0, temporal   
-            embeddings are disabled.  
-        hidden_size (int): Dimension of the embedding vectors.  
+    Args:
+        c_in (int): Number of input channels (variates) in the time series.
+        exog_input_size (int): Number of exogenous/temporal features. If 0, temporal
+            embeddings are disabled.
+        hidden_size (int): Dimension of the embedding vectors.
         pos_embedding (bool): Whether to include positional embeddings.
         dropout (float): Dropout rate applied to the final embeddings.
+        temporal_embedding (str): Which temporal encoder to use for exogenous features.
+            ``"native"`` (default) uses a simple bias-free linear projection
+            (``TimeFeatureEmbedding``).  ``"torchembed"`` uses
+            ``TorchembedTemporalEmbedding``, which applies a composable
+            ``CyclicEmbedding`` (sin/cos pair) to every feature column before
+            projecting to *hidden_size*; requires ``pip install torchembed>=0.3.1``.
+        torchembed_periods (list[float] | None): Explicit cyclic periods passed to
+            ``TorchembedTemporalEmbedding`` when *temporal_embedding="torchembed"*.
+            Defaults to ``None``, which infers periods from the calendar convention
+            ``[12, 31, 7, 24, 60]``.
 
     Returns:
         (torch.Tensor): Combined embeddings of shape [batch, seq_len, hidden_size] after
@@ -955,13 +1059,19 @@ class DataEmbedding(nn.Module):
     Notes:
         - Value embeddings use `TokenEmbedding` with 1D convolution (kernel_size=3).
         - Positional embeddings use sinusoidal functions (sine for even dims, cosine for odd).
-        - Temporal embeddings use a linear layer to project calendar features.
         - All three embeddings are summed element-wise before dropout is applied.
         - If `x_mark` is None, only value and positional embeddings are used.
     """
 
     def __init__(
-        self, c_in, exog_input_size, hidden_size, pos_embedding=True, dropout=0.1
+        self,
+        c_in,
+        exog_input_size,
+        hidden_size,
+        pos_embedding=True,
+        dropout=0.1,
+        temporal_embedding: str = "native",
+        torchembed_periods=None,
     ):
         super(DataEmbedding, self).__init__()
 
@@ -973,9 +1083,16 @@ class DataEmbedding(nn.Module):
             self.position_embedding = None
 
         if exog_input_size > 0:
-            self.temporal_embedding = TimeFeatureEmbedding(
-                input_size=exog_input_size, hidden_size=hidden_size
-            )
+            if temporal_embedding == "torchembed":
+                self.temporal_embedding = TorchembedTemporalEmbedding(
+                    input_size=exog_input_size,
+                    hidden_size=hidden_size,
+                    periods=torchembed_periods,
+                )
+            else:
+                self.temporal_embedding = TimeFeatureEmbedding(
+                    input_size=exog_input_size, hidden_size=hidden_size
+                )
         else:
             self.temporal_embedding = None
 

--- a/neuralforecast/models/autoformer.py
+++ b/neuralforecast/models/autoformer.py
@@ -482,6 +482,7 @@ class Autoformer(BaseModel):
         encoder_layers: int = 2,
         decoder_layers: int = 1,
         MovingAvg_window: int = 25,
+        temporal_embedding: str = "native",
         loss=MAE(),
         valid_loss=None,
         max_steps: int = 5000,
@@ -567,6 +568,7 @@ class Autoformer(BaseModel):
             hidden_size=hidden_size,
             pos_embedding=False,
             dropout=dropout,
+            temporal_embedding=temporal_embedding,
         )
         self.dec_embedding = DataEmbedding(
             self.dec_in,
@@ -574,6 +576,7 @@ class Autoformer(BaseModel):
             hidden_size=hidden_size,
             pos_embedding=False,
             dropout=dropout,
+            temporal_embedding=temporal_embedding,
         )
 
         # Encoder

--- a/neuralforecast/models/fedformer.py
+++ b/neuralforecast/models/fedformer.py
@@ -480,6 +480,7 @@ class FEDformer(BaseModel):
         encoder_layers: int = 2,
         decoder_layers: int = 1,
         MovingAvg_window: int = 25,
+        temporal_embedding: str = "native",
         loss=MAE(),
         valid_loss=None,
         max_steps: int = 5000,
@@ -568,6 +569,7 @@ class FEDformer(BaseModel):
             hidden_size=hidden_size,
             pos_embedding=False,
             dropout=dropout,
+            temporal_embedding=temporal_embedding,
         )
         self.dec_embedding = DataEmbedding(
             self.dec_in,
@@ -575,6 +577,7 @@ class FEDformer(BaseModel):
             hidden_size=hidden_size,
             pos_embedding=False,
             dropout=dropout,
+            temporal_embedding=temporal_embedding,
         )
 
         encoder_self_att = FourierBlock(

--- a/neuralforecast/models/informer.py
+++ b/neuralforecast/models/informer.py
@@ -210,6 +210,13 @@ class Informer(BaseModel):
         encoder_layers (int): number of layers for the TCN encoder.
         decoder_layers (int): number of layers for the MLP decoder.
         distil (bool): wether the Informer decoder uses bottlenecks.
+        temporal_embedding (str): temporal encoder for exogenous features.
+            ``"native"`` (default) uses a linear projection (``TimeFeatureEmbedding``).
+            ``"torchembed"`` uses composable cyclic (sin/cos) encoders from the
+            `torchembed <https://github.com/liodon-ai/torchembed>`_ library,
+            which produces periodic representations that are invariant to cyclic
+            shifts — better suited for calendar features such as hour-of-day or
+            day-of-week.  Requires ``pip install torchembed>=0.3.1``.
         loss (PyTorch module): instantiated train loss class from [losses collection](./losses.pytorch.html).
         valid_loss (PyTorch module): instantiated valid loss class from [losses collection](./losses.pytorch.html).
         max_steps (int): maximum number of training steps.
@@ -263,6 +270,7 @@ class Informer(BaseModel):
         encoder_layers: int = 2,
         decoder_layers: int = 1,
         distil: bool = True,
+        temporal_embedding: str = "native",
         loss=MAE(),
         valid_loss=None,
         max_steps: int = 5000,
@@ -345,6 +353,7 @@ class Informer(BaseModel):
             hidden_size=hidden_size,
             pos_embedding=True,
             dropout=dropout,
+            temporal_embedding=temporal_embedding,
         )
         self.dec_embedding = DataEmbedding(
             self.dec_in,
@@ -352,6 +361,7 @@ class Informer(BaseModel):
             hidden_size=hidden_size,
             pos_embedding=True,
             dropout=dropout,
+            temporal_embedding=temporal_embedding,
         )
 
         # Encoder

--- a/neuralforecast/models/timesnet.py
+++ b/neuralforecast/models/timesnet.py
@@ -189,6 +189,7 @@ class TimesNet(BaseModel):
         top_k: int = 5,
         num_kernels: int = 6,
         encoder_layers: int = 2,
+        temporal_embedding: str = "native",
         loss=MAE(),
         valid_loss=None,
         max_steps: int = 1000,
@@ -274,6 +275,7 @@ class TimesNet(BaseModel):
             hidden_size=hidden_size,
             pos_embedding=True,  # Original implementation uses true
             dropout=dropout,
+            temporal_embedding=temporal_embedding,
         )
         self.encoder_layers = encoder_layers
         self.layer_norm = nn.LayerNorm(hidden_size)

--- a/neuralforecast/models/vanillatransformer.py
+++ b/neuralforecast/models/vanillatransformer.py
@@ -53,6 +53,11 @@ class VanillaTransformer(BaseModel):
         activation (str): activation from ['ReLU', 'Softplus', 'Tanh', 'SELU', 'LeakyReLU', 'PReLU', 'Sigmoid', 'GELU'].
         encoder_layers (int): number of layers for the TCN encoder.
         decoder_layers (int): number of layers for the MLP decoder.
+        temporal_embedding (str): temporal encoder for exogenous features.
+            ``"native"`` (default) uses a linear projection (``TimeFeatureEmbedding``).
+            ``"torchembed"`` uses composable cyclic (sin/cos) encoders from
+            `torchembed <https://github.com/liodon-ai/torchembed>`_.
+            Requires ``pip install torchembed>=0.3.1``.
         loss (PyTorch module): instantiated train loss class from [losses collection](./losses.pytorch.html).
         valid_loss (PyTorch module): instantiated valid loss class from [losses collection](./losses.pytorch.html).
         max_steps (int): maximum number of training steps.
@@ -108,6 +113,7 @@ class VanillaTransformer(BaseModel):
         activation: str = "gelu",
         encoder_layers: int = 2,
         decoder_layers: int = 1,
+        temporal_embedding: str = "native",
         loss=MAE(),
         valid_loss=None,
         max_steps: int = 5000,
@@ -190,6 +196,7 @@ class VanillaTransformer(BaseModel):
             hidden_size=hidden_size,
             pos_embedding=True,
             dropout=dropout,
+            temporal_embedding=temporal_embedding,
         )
         self.dec_embedding = DataEmbedding(
             self.dec_in,
@@ -197,6 +204,7 @@ class VanillaTransformer(BaseModel):
             hidden_size=hidden_size,
             pos_embedding=True,
             dropout=dropout,
+            temporal_embedding=temporal_embedding,
         )
 
         # Encoder

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
 ]
 [project.optional-dependencies]
 spark = ["fugue", "pyspark>=3.5", "pyarrow>=23.0.1"]
+torchembed = ["torchembed>=0.3.1"]
 
 [dependency-groups]
 aws = ["fsspec[s3]"]


### PR DESCRIPTION
## Summary

This PR integrates [`torchembed`](https://github.com/liodon-ai/torchembed) (v0.3.1+) as an optional temporal feature encoder for the five transformer-family models in neuralforecast that use `DataEmbedding`: **Informer, VanillaTransformer, Autoformer, FEDformer, and TimesNet**.

### The problem with the current `TimeFeatureEmbedding`

The native implementation projects exogenous calendar features (hour-of-day, day-of-week, month, …) with a single bias-free linear layer:

```python
# native — treats calendar values as plain continuous scalars
self.embed = nn.Linear(input_size, hidden_size, bias=False)
```

This ignores the **cyclic topology** of calendar features: in a linear space, hour 23 and hour 0 are 23 units apart, but in real time they are adjacent.  The model has to learn this symmetry from data, wasting capacity and slowing convergence.

### What torchembed adds

`torchembed.temporal.CyclicEmbedding` encodes each feature as a `(sin, cos)` pair that wraps correctly at the period boundary:

```python
angle = 2π × x / period
encoding = [sin(angle), cos(angle)]  # ‖encoding‖ is constant; distance reflects cyclic proximity
```

Hour 23 and hour 0 are now 2π/24 apart — geometrically adjacent — without the model having to discover this.

### Integration design

A new `TorchembedTemporalEmbedding` module is added to `neuralforecast/common/_modules.py`.  It applies one `CyclicEmbedding` per exogenous feature column, concatenates the `2 × n_features` sin/cos vectors, then projects to `hidden_size` with a single linear layer.

`DataEmbedding` gains two new keyword arguments:

| Argument | Type | Default | Description |
|---|---|---|---|
| `temporal_embedding` | `str` | `"native"` | `"native"` keeps existing behaviour; `"torchembed"` uses cyclic encodings |
| `torchembed_periods` | `list[float] \| None` | `None` | Per-feature periods; defaults to `[12, 31, 7, 24, 60]` (month/day/weekday/hour/minute) |

Each affected model (`Informer`, `VanillaTransformer`, `Autoformer`, `FEDformer`, `TimesNet`) exposes `temporal_embedding: str = "native"` in its `__init__` and threads it through to `DataEmbedding`.

### Usage

```python
from neuralforecast.models import Informer

model = Informer(
    h=24,
    input_size=96,
    futr_exog_list=["hour_of_day", "day_of_week", "month"],
    temporal_embedding="torchembed",   # cyclic sin/cos encoding per feature
)
```

```bash
# Install with the optional extra
pip install 'neuralforecast[torchembed]'
# or standalone
pip install torchembed>=0.3.1
```

### Zero breaking changes

- Default is `"native"` — all existing code, checkpoints, and configs are unaffected.
- `torchembed` is imported **lazily** inside `TorchembedTemporalEmbedding.__init__`, so the library remains importable even without torchembed installed.  A clear `ImportError` with install instructions surfaces only when the backend is actually selected.

## Files changed

| File | Change |
|---|---|
| `neuralforecast/common/_modules.py` | Add `TorchembedTemporalEmbedding`; extend `DataEmbedding` with `temporal_embedding` and `torchembed_periods` kwargs |
| `neuralforecast/models/informer.py` | Add `temporal_embedding` param; pass to `DataEmbedding` |
| `neuralforecast/models/vanillatransformer.py` | Same |
| `neuralforecast/models/autoformer.py` | Same |
| `neuralforecast/models/fedformer.py` | Same |
| `neuralforecast/models/timesnet.py` | Same |
| `pyproject.toml` | Add `[project.optional-dependencies] torchembed = ["torchembed>=0.3.1"]` |

## Test plan

- [ ] Instantiate each affected model with `temporal_embedding="native"` (default) — confirm no regressions
- [ ] Instantiate each model with `temporal_embedding="torchembed"` and a non-empty `futr_exog_list` — confirm forward pass shape is correct
- [ ] Instantiate with `temporal_embedding="torchembed"` without torchembed installed — confirm `ImportError` message includes install instructions
- [ ] Confirm `temporal_embedding="torchembed"` with `futr_exog_list=[]` (no exog) creates no embedding layer (same as native path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)