### PR TITLE
fix: use per-series static features in predict_insample

### DIFF
--- a/neuralforecast/core.py
+++ b/neuralforecast/core.py
@@ -2437,7 +2437,9 @@ class NeuralForecast:
                         self.dataset.indptr[i] : self.dataset.indptr[i + 1]
                     ],
                     temporal_cols=self.dataset.temporal_cols,
-                    static=self.dataset.static,
+                    static=None
+                    if self.dataset.static is None
+                    else self.dataset.static[i : i + 1],
                     static_cols=self.dataset.static_cols,
                     indptr=np.array([0, series_length]),
                     y_idx=self.dataset.y_idx,
@@ -2460,7 +2462,9 @@ class NeuralForecast:
                         self.dataset.indptr[i] : self.dataset.indptr[i + 1]
                     ],
                     temporal_cols=self.dataset.temporal_cols,
-                    static=self.dataset.static,
+                    static=None
+                    if self.dataset.static is None
+                    else self.dataset.static[i : i + 1],
                     static_cols=self.dataset.static_cols,
                     indptr=np.array([0, series_length]),
                     y_idx=self.dataset.y_idx,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2841,3 +2841,31 @@ def test_trainer_caching(setup_airplane_data):
     model._pred_trainer_kwargs = {**model._pred_trainer_kwargs, "enable_checkpointing": True}
     nf.predict()
     assert model._pred_trainer is not trainer_2, "Trainer should be replaced when a kwarg value changes"
+
+
+def test_predict_insample_uses_correct_static_per_series():
+    """Regression: predict_insample built each single-series dataset with the full
+    static array, so every series was predicted with the first series' static
+    features. Two series with identical history but different static must yield
+    different insample predictions."""
+    n = 48
+    df = pd.DataFrame(
+        {
+            "unique_id": ["A"] * n + ["B"] * n,
+            "ds": np.tile(pd.date_range("2020-01-01", periods=n, freq="D"), 2),
+            "y": np.tile(np.arange(n, dtype=float), 2),  # identical history for A and B
+        }
+    )
+    static_df = pd.DataFrame({"unique_id": ["A", "B"], "sval": [0.0, 1000.0]})
+
+    nf = NeuralForecast(
+        models=[NHITS(h=6, input_size=12, max_steps=2, stat_exog_list=["sval"])],
+        freq="D",
+    )
+    nf.fit(df, static_df=static_df)
+    ins = nf.predict_insample()
+
+    a = ins[ins["unique_id"] == "A"]["NHITS"].to_numpy()
+    b = ins[ins["unique_id"] == "B"]["NHITS"].to_numpy()
+    # Same history, different static -> predictions must differ once static is aligned.
+    assert not np.allclose(a, b), "series B was predicted with series A's static features"


### PR DESCRIPTION
### Summary

`predict_insample` builds a single-series `TimeSeriesDataset` for each series, but passed the **full** static array into every one:

```python
series_dataset = TimeSeriesDataset(
    temporal=self.dataset.temporal[self.dataset.indptr[i] : self.dataset.indptr[i + 1]],
    ...
    static=self.dataset.static,   # full [n_series, n_static] array
    indptr=np.array([0, series_length]),
    ...
)
```

Each of these datasets has a single group, so `TimeSeriesDataset.__getitem__(0)` runs `self.static[idx, :]` with `idx == 0` and returns **series 0's static row for every series**. As a result, for any model trained with static exogenous features, `predict_insample()` computes the insample forecasts of series `1…N-1` using series 0's static features (series 0 is correct only by coincidence). No error is raised — the numbers are just silently wrong. `trim_dataset` forwards `static` unchanged, so the `test_size > 0` branch is affected too.

This was introduced when static support was added to `predict_insample` in #1349.

### Fix

Slice the static row for series `i` (guarding `None`), so each single-series dataset carries its own statics — matching what `__getitem__` expects.

### Reproduction

Building the single-series datasets the way `predict_insample` does, with statics `[10, 20, 30]` for series `A, B, C`:

```
expected per series: [10.0, 20.0, 30.0]
before fix:          [10.0, 10.0, 10.0]   # every series gets A's static
after fix:           [10.0, 20.0, 30.0]
```

### Test

Added `test_predict_insample_uses_correct_static_per_series`: two series with identical history but different static features must produce different insample predictions (they were identical before the fix because both used series 0's static). It fails on `main` and passes with the fix.

`pytest tests/test_core.py -k "static or insample"` → all green (24 tests).
