### PR TITLE
[FIX] Fix AutoHINT ray serialization issue

### DIFF
--- a/neuralforecast/auto.py
+++ b/neuralforecast/auto.py
@@ -2219,11 +2219,7 @@ class AutoHINT(BaseAuto):
         random_seed=None,
         distributed_config=None,
     ):
-        # The Ray trainable is built from the bound method `self._train_tune`,
-        # which serializes the whole `AutoHINT` instance (including `self.S`) into
-        # every trial actor. For a large summing matrix this blows past Ray's
-        # FUNCTION_SIZE_ERROR_THRESHOLD (see issue #559). Move `S` into the Ray
-        # object store so the captured `self.S` is a lightweight ObjectRef; the
+        # Move `S` into the Ray object store so the captured `self.S` is a lightweight ObjectRef; the
         # array is fetched once per actor via `ray.get` in `_fit_model`.
         original_S = self.S
         moved_to_store = False

--- a/neuralforecast/auto.py
+++ b/neuralforecast/auto.py
@@ -9,6 +9,8 @@ __all__ = ['AutoRNN', 'AutoLSTM', 'AutoGRU', 'AutoTCN', 'AutoDeepAR', 'AutoDilat
            'AutoXLinear', 'RayOptions', 'OptunaOptions']
 
 
+import numpy as np
+import ray
 from ray import tune
 from ray.tune.search.basic_variant import BasicVariantGenerator
 
@@ -2193,8 +2195,12 @@ class AutoHINT(BaseAuto):
         # Overwrite _fit_model for HINT two-stage instantiation
         reconciliation = config.pop("reconciliation")
         base_model = cls_model(**config)
+        # `S` may have been placed in the Ray object store (see `fit`) to avoid
+        # serializing the full summing matrix into every trial actor. Resolve the
+        # ObjectRef back into the array before instantiating HINT.
+        S = ray.get(self.S) if isinstance(self.S, ray.ObjectRef) else self.S
         model = HINT(
-            h=base_model.h, model=base_model, S=self.S, reconciliation=reconciliation
+            h=base_model.h, model=base_model, S=S, reconciliation=reconciliation
         )
         model.test_size = test_size
         model = model.fit(
@@ -2204,6 +2210,39 @@ class AutoHINT(BaseAuto):
             distributed_config=distributed_config,
         )
         return model
+
+    def fit(
+        self,
+        dataset,
+        val_size=0,
+        test_size=0,
+        random_seed=None,
+        distributed_config=None,
+    ):
+        # The Ray trainable is built from the bound method `self._train_tune`,
+        # which serializes the whole `AutoHINT` instance (including `self.S`) into
+        # every trial actor. For a large summing matrix this blows past Ray's
+        # FUNCTION_SIZE_ERROR_THRESHOLD (see issue #559). Move `S` into the Ray
+        # object store so the captured `self.S` is a lightweight ObjectRef; the
+        # array is fetched once per actor via `ray.get` in `_fit_model`.
+        original_S = self.S
+        moved_to_store = False
+        if self.backend == "ray" and isinstance(self.S, np.ndarray):
+            if not ray.is_initialized():
+                ray.init()
+            self.S = ray.put(self.S)
+            moved_to_store = True
+        try:
+            return super().fit(
+                dataset,
+                val_size=val_size,
+                test_size=test_size,
+                random_seed=random_seed,
+                distributed_config=distributed_config,
+            )
+        finally:
+            if moved_to_store:
+                self.S = original_S
 
     @classmethod
     def get_default_config(cls, h, backend, n_series=None):

--- a/neuralforecast/auto.py
+++ b/neuralforecast/auto.py
@@ -2188,6 +2188,12 @@ class AutoHINT(BaseAuto):
                             try tune.choice(['BottomUp', 'MinTraceOLS', 'MinTraceWLS'])"
             )
         self.S = S
+        # `save_hyperparameters` captures `S` into `_hparams`. `S` is a summing matrix, not a tunable
+        # hyperparameter. Drop copies of `S`.
+        for _hparams in ("_hparams", "_hparams_initial"):
+            hparams = getattr(self, _hparams, None)
+            if hparams is not None:
+                hparams.pop("S", None)
 
     def _fit_model(
         self, cls_model, config, dataset, val_size, test_size, distributed_config=None

--- a/tests/test_models/test_hint.py
+++ b/tests/test_models/test_hint.py
@@ -167,14 +167,11 @@ def test_auto_hint_large_S_not_captured_in_trainable():
     captured_size = len(cpickle.dumps(auto._train_tune))
     assert captured_size > RAY_FUNCTION_SIZE_THRESHOLD
 
-    # Once `S` lives in the object store, `self` no longer
-    # holds the ndarray directly. Ray captures the ObjectRef by reference in the
-    # actual actor-registration path, so the array is not re-serialized per trial.
     if not ray.is_initialized():
         ray.init()
     auto.S = ray.put(S)
-    assert isinstance(auto.S, ray.ObjectRef)
-    assert not isinstance(auto.S, np.ndarray)
+    recaptured_size = len(cpickle.dumps(auto._train_tune))
+    assert recaptured_size < RAY_FUNCTION_SIZE_THRESHOLD
 
 
 # `AutoHINT.fit` must move `S` into the Ray object store before the trainable is

--- a/tests/test_models/test_hint.py
+++ b/tests/test_models/test_hint.py
@@ -6,7 +6,7 @@ import ray.cloudpickle as cpickle
 from ray import tune
 
 from neuralforecast import NeuralForecast
-from neuralforecast.auto import AutoHINT
+from neuralforecast.auto import AutoHINT, RayOptions
 from neuralforecast.common._base_auto import BaseAuto
 from neuralforecast.losses.pytorch import GMM, sCRPS
 from neuralforecast.models import HINT, NHITS
@@ -147,6 +147,7 @@ def _make_auto_hint(S, quantiles, config=None):
         S=S,
         config=config,
         num_samples=1,
+        ray_options=RayOptions(cpus=1, gpus=0),
     )
 
 

--- a/tests/test_models/test_hint.py
+++ b/tests/test_models/test_hint.py
@@ -1,9 +1,18 @@
 import numpy as np
 import pandas as pd
+import pytest
+import ray
+import ray.cloudpickle as cpickle
+from ray import tune
 
 from neuralforecast import NeuralForecast
-from neuralforecast.losses.pytorch import GMM
+from neuralforecast.auto import AutoHINT
+from neuralforecast.common._base_auto import BaseAuto
+from neuralforecast.losses.pytorch import GMM, sCRPS
 from neuralforecast.models import HINT, NHITS
+
+# Ray refuses to serialize a trainable larger than this (FUNCTION_SIZE_ERROR_THRESHOLD).
+RAY_FUNCTION_SIZE_THRESHOLD = 95 * 1024**2
 
 # Unit test to check hierarchical coherence
 # Probabilistic coherent => Sample coherent => Mean coherence
@@ -117,6 +126,104 @@ def test_hint_fit_predict():
     parent_children_dict = {0: [1, 2], 1: [3, 4], 2: [5, 6]}
     for _, df in forecasts.groupby("ds"):
         hint_mean = df["HINT"].values
+        for parent_idx, children_list in parent_children_dict.items():
+            parent_value = hint_mean[parent_idx]
+            children_sum = hint_mean[children_list].sum()
+            np.testing.assert_allclose(children_sum, parent_value, rtol=1e-6)
+
+
+def _make_auto_hint(S, quantiles, config=None):
+    if config is None:
+        config = {
+            "input_size": tune.choice([8]),
+            "max_steps": tune.choice([1]),
+            "reconciliation": tune.choice(["BottomUp"]),
+        }
+    return AutoHINT(
+        NHITS,
+        h=4,
+        loss=GMM(n_components=2, quantiles=quantiles, num_samples=len(quantiles)),
+        valid_loss=sCRPS(quantiles=quantiles),
+        S=S,
+        config=config,
+        num_samples=1,
+    )
+
+
+# Move `S` to the object store replaces the
+# captured ndarray with a lightweight ObjectRef that Ray transmits by reference.
+def test_auto_hint_large_S_not_captured_in_trainable():
+    _, _, quantiles = setup_synthetic_data()
+    # ~100 MiB float64 matrix -> above Ray's 95 MiB threshold when captured.
+    n_bottom = 3600
+    S = np.ones((n_bottom + 1, n_bottom), dtype=np.float64)
+    assert S.nbytes > RAY_FUNCTION_SIZE_THRESHOLD
+
+    auto = _make_auto_hint(S, quantiles)
+
+    # Pre-fix behaviour: with `S` stored as a raw ndarray, the bound method drags
+    # the whole matrix into the pickled trainable -> Ray rejects the actor.
+    captured_size = len(cpickle.dumps(auto._train_tune))
+    assert captured_size > RAY_FUNCTION_SIZE_THRESHOLD
+
+    # Once `S` lives in the object store, `self` no longer
+    # holds the ndarray directly. Ray captures the ObjectRef by reference in the
+    # actual actor-registration path, so the array is not re-serialized per trial.
+    if not ray.is_initialized():
+        ray.init()
+    auto.S = ray.put(S)
+    assert isinstance(auto.S, ray.ObjectRef)
+    assert not isinstance(auto.S, np.ndarray)
+
+
+# `AutoHINT.fit` must move `S` into the Ray object store before the trainable is
+# built, then restore the original array so the instance stays reusable.
+def test_auto_hint_fit_moves_S_to_object_store(monkeypatch):
+    _, _, quantiles = setup_synthetic_data()
+    S = np.ones((5, 4), dtype=np.float64)
+    auto = _make_auto_hint(S, quantiles)
+
+    captured = {}
+
+    def fake_super_fit(
+        self, dataset, val_size=0, test_size=0, random_seed=None, distributed_config=None
+    ):
+        captured["is_ref"] = isinstance(self.S, ray.ObjectRef)
+        return "ok"
+
+    monkeypatch.setattr(BaseAuto, "fit", fake_super_fit)
+
+    result = auto.fit(dataset=None, val_size=4)
+
+    assert result == "ok"
+    assert captured["is_ref"], "S was not moved to the Ray object store during fit."
+    assert isinstance(auto.S, np.ndarray), "S was not restored after fit."
+
+
+# End-to-end: confirms the object-store ObjectRef round-trips back into a usable
+# array inside `_fit_model` (via `ray.get`), producing coherent forecasts.
+@pytest.mark.filterwarnings("ignore")
+def test_auto_hint_fit_predict():
+    Y_df, S, quantiles = setup_synthetic_data()
+    config = {
+        "input_size": tune.choice([4]),
+        "max_steps": tune.choice([1]),
+        "val_check_steps": tune.choice([1]),
+        "learning_rate": tune.choice([1e-3]),
+        "reconciliation": tune.choice(["BottomUp"]),
+    }
+    auto = _make_auto_hint(S, quantiles, config=config)
+
+    nf = NeuralForecast(models=[auto], freq="Q")
+    nf.fit(df=Y_df, val_size=4)
+    forecasts = nf.predict()
+
+    assert isinstance(auto.S, np.ndarray), "S was not restored after fit."
+    hint_col = [c for c in forecasts.columns if c.startswith("AutoHINT")][0]
+
+    parent_children_dict = {0: [1, 2], 1: [3, 4], 2: [5, 6]}
+    for _, df in forecasts.groupby("ds"):
+        hint_mean = df[hint_col].values
         for parent_idx, children_list in parent_children_dict.items():
             parent_value = hint_mean[parent_idx]
             children_sum = hint_mean[children_list].sum()


### PR DESCRIPTION
Previously, Ray would try to serialize the entire summation matrix, causing serialization errors. We now use an `ObjectRef` to prevent serializing a very large object and confirm AutoHINT runs end-to-end.