### PR TITLE
[FIX] Set default gpu=1 for Ray

### DIFF
--- a/neuralforecast/common/_base_auto.py
+++ b/neuralforecast/common/_base_auto.py
@@ -219,6 +219,15 @@ class BaseAuto(pl.LightningModule):
                 ray_options.cpus = cpu_count()
             if ray_options.gpus is None:
                 ray_options.gpus = min(1, torch.cuda.device_count())
+            elif ray_options.gpus > 1:
+                warnings.warn(
+                    f"Reserving {ray_options.gpus} GPUs per Ray trial makes the "
+                    "model launch DDP inside the trial actor, which is not "
+                    "supported and crashes with ActorDiedError. Use "
+                    "`ray_options=RayOptions(gpus=1)` and let Ray parallelize "
+                    "trials across the available GPUs, one GPU per trial.",
+                    UserWarning,
+                )
         if config_base.get("h", None) is not None:
             raise Exception("Please use `h` init argument instead of `config['h']`.")
         if config_base.get("loss", None) is not None:

--- a/neuralforecast/common/_base_auto.py
+++ b/neuralforecast/common/_base_auto.py
@@ -30,7 +30,7 @@ class RayOptions:
             See https://docs.ray.io/en/latest/tune/api/schedulers.html.
         cpus (int, optional): Number of cpus to use during optimization.
             Defaults to `os.cpu_count()` when unset.
-        gpus (int, optional): Number of gpus to reserve per trial. Defaults to
+        gpus (float, optional): Number of gpus to reserve per trial. Defaults to
             `1` when GPUs are available (`0` otherwise), so Ray parallelizes
             trials across the available GPUs, one GPU per trial. DDP within a
             single Ray trial is not supported; reserving every GPU per trial and
@@ -40,7 +40,7 @@ class RayOptions:
     run_config: Optional[Any] = None
     scheduler: Optional[Any] = None
     cpus: Optional[int] = None
-    gpus: Optional[int] = None
+    gpus: Optional[float] = None
 
 
 @dataclass
@@ -221,11 +221,13 @@ class BaseAuto(pl.LightningModule):
                 ray_options.gpus = min(1, torch.cuda.device_count())
             elif ray_options.gpus > 1:
                 warnings.warn(
-                    f"Reserving {ray_options.gpus} GPUs per Ray trial makes the "
-                    "model launch DDP inside the trial actor, which is not "
-                    "supported and crashes with ActorDiedError. Use "
-                    "`ray_options=RayOptions(gpus=1)` and let Ray parallelize "
-                    "trials across the available GPUs, one GPU per trial.",
+                    f"Reserving {ray_options.gpus} GPUs per Ray trial will crash "
+                    "with ActorDiedError unless the model config pins `devices=1`: "
+                    "with multiple visible GPUs Lightning defaults to DDP, which "
+                    "is not supported inside a Ray trial actor. Either set "
+                    "`devices=1` in the config (e.g. to reserve extra GPUs for "
+                    "memory headroom), or use `ray_options=RayOptions(gpus=1)` and "
+                    "let Ray parallelize trials across the available GPUs.",
                     UserWarning,
                 )
         if config_base.get("h", None) is not None:

--- a/neuralforecast/common/_base_auto.py
+++ b/neuralforecast/common/_base_auto.py
@@ -30,8 +30,11 @@ class RayOptions:
             See https://docs.ray.io/en/latest/tune/api/schedulers.html.
         cpus (int, optional): Number of cpus to use during optimization.
             Defaults to `os.cpu_count()` when unset.
-        gpus (int, optional): Number of gpus to use during optimization.
-            Defaults to `torch.cuda.device_count()` when unset.
+        gpus (int, optional): Number of gpus to reserve per trial. Defaults to
+            `1` when GPUs are available (`0` otherwise), so Ray parallelizes
+            trials across the available GPUs, one GPU per trial. DDP within a
+            single Ray trial is not supported; reserving every GPU per trial and
+            training with multiple devices crashes the trial actor.
     """
 
     run_config: Optional[Any] = None
@@ -215,7 +218,7 @@ class BaseAuto(pl.LightningModule):
             if ray_options.cpus is None:
                 ray_options.cpus = cpu_count()
             if ray_options.gpus is None:
-                ray_options.gpus = torch.cuda.device_count()
+                ray_options.gpus = min(1, torch.cuda.device_count())
         if config_base.get("h", None) is not None:
             raise Exception("Please use `h` init argument instead of `config['h']`.")
         if config_base.get("loss", None) is not None:

--- a/tests/test_common/test_base_auto.py
+++ b/tests/test_common/test_base_auto.py
@@ -1,5 +1,6 @@
 import logging
 import warnings
+from unittest.mock import patch
 
 import numpy as np
 import optuna
@@ -127,6 +128,25 @@ def test_instantiation(setup_config):
     )
     assert str(type(auto.loss)) == "<class 'neuralforecast.losses.pytorch.MAE'>"
     assert str(type(auto.valid_loss)) == "<class 'neuralforecast.losses.pytorch.MSE'>"
+
+
+def test_ray_gpus_default_single_gpu_per_trial(setup_config):
+    # On a multi-GPU node the Ray backend must reserve
+    # a single GPU per trial. Reserving every GPU per trial makes the model
+    # default to DDP inside the Ray actor, which crashes with ActorDiedError.
+    with patch(
+        "neuralforecast.common._base_auto.torch.cuda.device_count", return_value=4
+    ):
+        auto = BaseAuto(
+            h=12,
+            loss=MAE(),
+            valid_loss=MSE(),
+            cls_model=MLP,
+            config=setup_config,
+            num_samples=1,
+            backend="ray",
+        )
+    assert auto.gpus == 1
 
 def test_validation_default(setup_config):
     auto = BaseAuto(

--- a/tests/test_common/test_base_auto.py
+++ b/tests/test_common/test_base_auto.py
@@ -161,7 +161,7 @@ def test_ray_gpus_default_is_single_gpu_per_trial(setup_config):
         assert override.gpus == 0.5  # explicit value untouched
 
         # gpus > 1 re-enters the DDP-in-actor trap: keep the value but warn.
-        with pytest.warns(UserWarning, match="DDP inside the trial actor"):
+        with pytest.warns(UserWarning, match="unless the model config pins"):
             multi = BaseAuto(
                 h=12,
                 loss=MAE(),

--- a/tests/test_common/test_base_auto.py
+++ b/tests/test_common/test_base_auto.py
@@ -131,8 +131,9 @@ def test_instantiation(setup_config):
 
 
 def test_ray_gpus_default_is_single_gpu_per_trial(setup_config):
-    # Reserving every GPU per trial makes the model launch DDP inside the
-    # Ray actor and crash. Default to one GPU per trial; respect explicit overrides.
+    # Reserving every GPU per trial makes the model launch DDP inside the Ray
+    # actor and crash. Default to one GPU per trial; keep the override untouched
+    # for fractional reservations (e.g. 0.5 packs two trials onto one GPU).
     with patch(
         "neuralforecast.common._base_auto.torch.cuda.device_count", return_value=4
     ):
@@ -155,9 +156,23 @@ def test_ray_gpus_default_is_single_gpu_per_trial(setup_config):
             config=setup_config,
             num_samples=1,
             backend="ray",
-            ray_options=RayOptions(gpus=2),
+            ray_options=RayOptions(gpus=0.5),
         )
-        assert override.gpus == 2  # explicit value untouched
+        assert override.gpus == 0.5  # explicit value untouched
+
+        # gpus > 1 re-enters the DDP-in-actor trap: keep the value but warn.
+        with pytest.warns(UserWarning, match="DDP inside the trial actor"):
+            multi = BaseAuto(
+                h=12,
+                loss=MAE(),
+                valid_loss=MSE(),
+                cls_model=MLP,
+                config=setup_config,
+                num_samples=1,
+                backend="ray",
+                ray_options=RayOptions(gpus=2),
+            )
+        assert multi.gpus == 2
 
 def test_validation_default(setup_config):
     auto = BaseAuto(

--- a/tests/test_common/test_base_auto.py
+++ b/tests/test_common/test_base_auto.py
@@ -131,7 +131,7 @@ def test_instantiation(setup_config):
 
 
 def test_ray_gpus_default_is_single_gpu_per_trial(setup_config):
-    # #1291: reserving every GPU per trial makes the model launch DDP inside the
+    # Reserving every GPU per trial makes the model launch DDP inside the
     # Ray actor and crash. Default to one GPU per trial; respect explicit overrides.
     with patch(
         "neuralforecast.common._base_auto.torch.cuda.device_count", return_value=4

--- a/tests/test_common/test_base_auto.py
+++ b/tests/test_common/test_base_auto.py
@@ -130,10 +130,9 @@ def test_instantiation(setup_config):
     assert str(type(auto.valid_loss)) == "<class 'neuralforecast.losses.pytorch.MSE'>"
 
 
-def test_ray_gpus_default_single_gpu_per_trial(setup_config):
-    # On a multi-GPU node the Ray backend must reserve
-    # a single GPU per trial. Reserving every GPU per trial makes the model
-    # default to DDP inside the Ray actor, which crashes with ActorDiedError.
+def test_ray_gpus_default_is_single_gpu_per_trial(setup_config):
+    # #1291: reserving every GPU per trial makes the model launch DDP inside the
+    # Ray actor and crash. Default to one GPU per trial; respect explicit overrides.
     with patch(
         "neuralforecast.common._base_auto.torch.cuda.device_count", return_value=4
     ):
@@ -146,7 +145,19 @@ def test_ray_gpus_default_single_gpu_per_trial(setup_config):
             num_samples=1,
             backend="ray",
         )
-    assert auto.gpus == 1
+        assert auto.gpus == 1  # not 4
+
+        override = BaseAuto(
+            h=12,
+            loss=MAE(),
+            valid_loss=MSE(),
+            cls_model=MLP,
+            config=setup_config,
+            num_samples=1,
+            backend="ray",
+            ray_options=RayOptions(gpus=2),
+        )
+        assert override.gpus == 2  # explicit value untouched
 
 def test_validation_default(setup_config):
     auto = BaseAuto(


### PR DESCRIPTION
The Ray backend now defaults to 1 GPU per trial (`min(1, device_count())`) instead of reserving every GPU per trial. 

Previously each trial grabbed all GPUs and the model launched DDP inside the Ray actor, which Ray kills with `ActorDiedError`. With the new default, Ray runs one trial per GPU in parallel (the standard HPO pattern) and no DDP is spawned inside a trial. Can be overridden with `ray_options=RayOptions(gpus=N)`. 