### PR TITLE
[FIX] Support DBFS paths in distributed partition listing

### DIFF
--- a/neuralforecast/core.py
+++ b/neuralforecast/core.py
@@ -139,8 +139,6 @@ def _as_distributed_file_uri(protocol: str, path: str) -> str:
     if protocol == "dbfs":
         dbfs_path = path if path.startswith("/") else f"/{path}"
         return _dbfs_path_for_pandas(f"dbfs:{dbfs_path}")
-    if path.startswith("/"):
-        return f"{protocol}://{path}"
     return f"{protocol}://{path}"
 
 

--- a/neuralforecast/core.py
+++ b/neuralforecast/core.py
@@ -86,6 +86,82 @@ from .losses.pytorch import HuberIQLoss, IQLoss, sCRPS
 warnings.filterwarnings("ignore", category=pl.utilities.warnings.PossibleUserWarning)
 
 
+def _fsspec_entry_path(entry: Union[str, Dict[str, Any]]) -> str:
+    """Normalize an ``fs.ls`` entry to a path string.
+
+    Some filesystems (notably Databricks DBFS via fsspec) return detail dicts
+    from ``ls`` even when callers expect plain path strings.
+    """
+    if isinstance(entry, dict):
+        name = entry.get("name")
+        if name is None:
+            raise ValueError(f"Cannot determine path from fsspec ls entry: {entry}")
+        return name
+    return entry
+
+
+def _fsspec_listdir(fs, path: str) -> List[str]:
+    """List paths from fsspec, always returning path strings."""
+    try:
+        entries = fs.ls(path, detail=False)
+    except TypeError:
+        # Implementations that do not accept ``detail``
+        entries = fs.ls(path)
+    return [_fsspec_entry_path(entry) for entry in entries]
+
+
+def _dbfs_path_for_pandas(path: str) -> str:
+    """Prefer the Databricks ``/dbfs`` FUSE mount when available.
+
+    Spark commonly writes with ``dbfs:/...`` URIs while pandas on the driver
+    reads more reliably from ``/dbfs/...`` when that mount exists.
+    """
+    import os
+
+    if not path.startswith("dbfs:"):
+        return path
+
+    rest = path.split(":", 1)[1]
+    while rest.startswith("//"):
+        rest = rest[1:]
+    if not rest.startswith("/"):
+        rest = f"/{rest}"
+    fuse_path = rest if rest.startswith("/dbfs/") else f"/dbfs{rest}"
+    if os.path.isdir("/dbfs"):
+        return fuse_path
+    return path
+
+
+def _as_distributed_file_uri(protocol: str, path: str) -> str:
+    """Build a readable URI/path for a distributed parquet partition."""
+    if path.startswith("/dbfs/") or path.startswith("dbfs:") or "://" in path:
+        return _dbfs_path_for_pandas(path)
+    if protocol == "dbfs":
+        dbfs_path = path if path.startswith("/") else f"/{path}"
+        return _dbfs_path_for_pandas(f"dbfs:{dbfs_path}")
+    if path.startswith("/"):
+        return f"{protocol}://{path}"
+    return f"{protocol}://{path}"
+
+
+def _list_distributed_parquet_files(fs, partitions_path: str) -> List[str]:
+    """List parquet partition files for distributed training.
+
+    Handles fsspec backends that return detail dicts from ``ls`` and normalizes
+    Databricks DBFS paths for pandas reads.
+    """
+    protocol = fs.protocol
+    if isinstance(protocol, tuple):
+        protocol = protocol[0]
+
+    files = []
+    for file in _fsspec_listdir(fs, partitions_path):
+        if not file.endswith("parquet"):
+            continue
+        files.append(_as_distributed_file_uri(protocol, file))
+    return files
+
+
 def _insample_times(
     times: np.ndarray,
     uids: Series,
@@ -520,14 +596,7 @@ class NeuralForecast:
         df = df.repartitionByRange(num_partitions, id_col)
         df.write.parquet(path=distributed_config.partitions_path, mode="overwrite")
         fs, _, _ = fsspec.get_fs_token_paths(distributed_config.partitions_path)
-        protocol = fs.protocol
-        if isinstance(protocol, tuple):
-            protocol = protocol[0]
-        files = [
-            f"{protocol}://{file}"
-            for file in fs.ls(distributed_config.partitions_path)
-            if file.endswith("parquet")
-        ]
+        files = _list_distributed_parquet_files(fs, distributed_config.partitions_path)
         return _FilesDataset(
             files=files,
             temporal_cols=temporal_cols,
@@ -2578,7 +2647,7 @@ class NeuralForecast:
             fs.makedirs(path)
         else:
             # Check if directory is empty to protect overwriting files
-            files = fs.ls(path)
+            files = _fsspec_listdir(fs, path)
 
             # Checking if the list is empty or not
             if files:
@@ -2679,7 +2748,9 @@ class NeuralForecast:
             path = path[:-1]
 
         fs, _, _ = fsspec.get_fs_token_paths(path)
-        files = [f.split("/")[-1] for f in fs.ls(path) if fs.isfile(f)]
+        files = [
+            f.split("/")[-1] for f in _fsspec_listdir(fs, path) if fs.isfile(f)
+        ]
 
         # Load models
         models_ckpt = [f for f in files if f.endswith(".ckpt")]

--- a/tests/test_distributed_paths.py
+++ b/tests/test_distributed_paths.py
@@ -1,0 +1,130 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from neuralforecast.core import (
+    _as_distributed_file_uri,
+    _dbfs_path_for_pandas,
+    _fsspec_entry_path,
+    _fsspec_listdir,
+    _list_distributed_parquet_files,
+)
+
+
+def test_fsspec_entry_path_from_string():
+    assert _fsspec_entry_path("dbfs:/tmp/part-0.parquet") == "dbfs:/tmp/part-0.parquet"
+
+
+def test_fsspec_entry_path_from_detail_dict():
+    assert (
+        _fsspec_entry_path(
+            {"name": "/tmp/part-0.parquet", "type": "file", "size": 123}
+        )
+        == "/tmp/part-0.parquet"
+    )
+
+
+def test_fsspec_entry_path_missing_name_raises():
+    with pytest.raises(ValueError, match="Cannot determine path"):
+        _fsspec_entry_path({"type": "file", "size": 1})
+
+
+def test_fsspec_listdir_normalizes_detail_dicts():
+    fs = MagicMock()
+    fs.ls.return_value = [
+        {"name": "/tmp/part-0.parquet", "type": "file", "size": 10},
+        {"name": "/tmp/_SUCCESS", "type": "file", "size": 0},
+    ]
+    assert _fsspec_listdir(fs, "dbfs:/tmp") == [
+        "/tmp/part-0.parquet",
+        "/tmp/_SUCCESS",
+    ]
+    fs.ls.assert_called_once_with("dbfs:/tmp", detail=False)
+
+
+def test_fsspec_listdir_falls_back_when_detail_unsupported():
+    fs = MagicMock()
+    fs.ls.side_effect = [
+        TypeError("detail"),
+        ["s3://bucket/part-0.parquet", "s3://bucket/_SUCCESS"],
+    ]
+    assert _fsspec_listdir(fs, "s3://bucket") == [
+        "s3://bucket/part-0.parquet",
+        "s3://bucket/_SUCCESS",
+    ]
+
+
+def test_dbfs_path_for_pandas_uses_fuse_when_available():
+    with patch("os.path.isdir", return_value=True):
+        assert (
+            _dbfs_path_for_pandas("dbfs:/FileStore/partitions/part-0.parquet")
+            == "/dbfs/FileStore/partitions/part-0.parquet"
+        )
+        assert (
+            _dbfs_path_for_pandas("dbfs:///FileStore/partitions/part-0.parquet")
+            == "/dbfs/FileStore/partitions/part-0.parquet"
+        )
+
+
+def test_dbfs_path_for_pandas_keeps_uri_without_fuse():
+    with patch("os.path.isdir", return_value=False):
+        assert (
+            _dbfs_path_for_pandas("dbfs:/FileStore/partitions/part-0.parquet")
+            == "dbfs:/FileStore/partitions/part-0.parquet"
+        )
+
+
+def test_as_distributed_file_uri_for_dbfs_and_s3():
+    with patch("os.path.isdir", return_value=False):
+        assert (
+            _as_distributed_file_uri("dbfs", "/FileStore/part-0.parquet")
+            == "dbfs:/FileStore/part-0.parquet"
+        )
+        assert (
+            _as_distributed_file_uri("s3", "bucket/part-0.parquet")
+            == "s3://bucket/part-0.parquet"
+        )
+
+
+def test_list_distributed_parquet_files_handles_dbfs_detail_dicts():
+    fs = MagicMock()
+    fs.protocol = "dbfs"
+    fs.ls.return_value = [
+        {
+            "name": "/FileStore/distributed/partitions/part-000.parquet",
+            "type": "file",
+            "size": 421,
+        },
+        {
+            "name": "/FileStore/distributed/partitions/_SUCCESS",
+            "type": "file",
+            "size": 0,
+        },
+        {
+            "name": "/FileStore/distributed/partitions/part-001.parquet",
+            "type": "file",
+            "size": 224,
+        },
+    ]
+
+    with patch("os.path.isdir", return_value=True):
+        files = _list_distributed_parquet_files(
+            fs, "dbfs:/FileStore/distributed/partitions"
+        )
+
+    assert files == [
+        "/dbfs/FileStore/distributed/partitions/part-000.parquet",
+        "/dbfs/FileStore/distributed/partitions/part-001.parquet",
+    ]
+
+
+def test_list_distributed_parquet_files_keeps_string_paths():
+    fs = MagicMock()
+    fs.protocol = ("s3", "s3a")
+    fs.ls.return_value = [
+        "bucket/partitions/part-000.parquet",
+        "bucket/partitions/_committed_123",
+    ]
+
+    files = _list_distributed_parquet_files(fs, "s3://bucket/partitions")
+    assert files == ["s3://bucket/partitions/part-000.parquet"]


### PR DESCRIPTION
## Summary
- Normalize `fsspec` `ls` results so both path strings and detail dicts work when collecting distributed parquet partitions (fixes the `dict` has no `endswith` failure on Databricks DBFS).
- Prefer the Databricks `/dbfs` FUSE mount for pandas reads when that mount is present, while keeping `dbfs:/...` URIs elsewhere.
- Reuse the same listing normalization in `save`/`load` directory checks.
- Add unit tests with a mocked filesystem covering the DBFS detail-dict case from #1045.

Closes #1045

## Test plan
- [x] `uv run pytest tests/test_distributed_paths.py -q --cov-fail-under=0`
- [x] `uv run ruff check neuralforecast/core.py tests/test_distributed_paths.py`
- [ ] Optional: re-run distributed fit on Databricks with `partitions_path='dbfs:/FileStore/...'`


Made with [Cursor](https://cursor.com)