### PR TITLE
docs: fix SOFTSSharp image path

### DIFF
--- a/docs/models.softssharp.html.md
+++ b/docs/models.softssharp.html.md
@@ -8,7 +8,7 @@ title: SOFTSSharp
 SOFTSSharp extends SOFTS by stochastically adding variable-position embeddings and multiple dropout layers inside the STAD aggregation-redistribution component, aiming to improve forecasting accuracy while preserving linear complexity.
 
 
-![Figure 1. Architecture of SOFTSSharp](imgs_models/softssharp.png)
+![Figure 1. Architecture of SOFTSSharp](./imgs_models/softssharp.png)
 *Figure 1. Architecture of SOFTSSharp*
 
 ## 1. SOFTSSharp


### PR DESCRIPTION
## What

Correct the SOFTSSharp architecture image path in the generated model page.

## Why

Mintlify interprets the bare image target from the model page as a site root path. The leading `./` resolves it inside the NeuralForecast model documentation directory.

## How

1. Make the existing image path explicitly relative to the current page.

## Testing

1. Confirmed the previous resolved target is broken.
2. Confirmed the corrected asset exists, is a valid 3016 by 1332 PNG, and matches the SOFTSSharp architecture content.
3. Verified the asset repeatedly and recorded SHA256 `945c39499f5815669aa01d88c368b07427ae9e7e18333c2a361c2569d0b1e88e`.
4. Ran the native Mintlify broken link checker against a fresh aggregate three times. Every run reported zero targeted findings.
5. Inspected the complete diff, ran `git diff --check`, and scanned the diff for credentials.

## Checklist

* [x] Only the broken image target changed.
* [x] The corrected asset exists and matches the page.
* [x] No model documentation content was otherwise modified.
