### PR TITLE
docs: improve forecasting model search metadata

### DIFF
--- a/docs/models.informer.html.md
+++ b/docs/models.informer.html.md
@@ -1,8 +1,8 @@
 ---
 description: >-
-  Informer: Efficient Transformer with ProbSparse attention for long-sequence time series forecasting. Reduces O(L^2) complexity for scalable predictions.
+  Build long horizon forecasts with Informer in NeuralForecast. Learn ProbSparse attention, architecture, parameters, and a complete Python workflow.
 output-file: models.informer.html
-title: Informer
+title: Informer Time Series Forecasting in Python
 ---
 
 The Informer model tackles the vanilla Transformer computational

--- a/docs/models.itransformer.html.md
+++ b/docs/models.itransformer.html.md
@@ -1,8 +1,8 @@
 ---
 description: >-
-  iTransformer: Inverted Transformer architecture for multivariate time series forecasting with attention on time points and feed-forward on series dimensions.
+  Build multivariate forecasts with iTransformer in NeuralForecast. Learn its inverted attention architecture, parameters, and Python workflow.
 output-file: models.itransformer.html
-title: iTransformer
+title: iTransformer Time Series Forecasting in Python
 ---
 
 The iTransformer model simply takes the Transformer architecture but it

--- a/docs/models.kan.html.md
+++ b/docs/models.kan.html.md
@@ -1,8 +1,8 @@
 ---
 description: >-
-  KAN: Kolmogorov-Arnold Networks for time series forecasting. MLP alternative using learnable activation functions for improved non-linear pattern modeling.
+  Build time series forecasts with Kolmogorov Arnold Networks in NeuralForecast. Compare KAN with MLP models and run a complete Python example.
 output-file: models.kan.html
-title: KAN
+title: KAN Time Series Forecasting in Python
 ---
 
 Kolmogorov-Arnold Networks (KANs) are an alternative to Multi-Layer

--- a/docs/models.patchtst.html.md
+++ b/docs/models.patchtst.html.md
@@ -1,8 +1,8 @@
 ---
 description: >-
-  PatchTST: Efficient Transformer model for multivariate forecasting using patched time series and channel-independence for scalable long-term predictions.
+  Build long horizon forecasts with PatchTST in NeuralForecast. Learn how temporal patches and channel independence work, then run a complete Python example.
 output-file: models.patchtst.html
-title: PatchTST
+title: PatchTST Time Series Forecasting in Python
 ---
 
 The PatchTST model is an efficient Transformer-based model for

--- a/docs/models.tft.html.md
+++ b/docs/models.tft.html.md
@@ -1,8 +1,8 @@
 ---
 description: >-
-  TFT: Temporal Fusion Transformer with interpretable multi-horizon forecasting. LSTM encoder, multi-head attention, variable selection for complex time series.
+  Build interpretable forecasts with Temporal Fusion Transformer in NeuralForecast using static, historic, and future variables in Python.
 output-file: models.tft.html
-title: TFT
+title: Temporal Fusion Transformer Forecasting in Python
 ---
 
 In summary Temporal Fusion Transformer (TFT) combines gating layers, an
@@ -468,5 +468,4 @@ $\mathrm{InterpretableMultiHead}(Q,K,V) = \tilde{H} W_{M}$. The
 mechanism has a great resemblence to a single attention layer, but it
 allows for $M$ multiple attention weights, and can be therefore be
 interpreted as the average ensemble of $M$ single attention layers.
-
 

--- a/nbs/docs/capabilities/cross_validation.ipynb
+++ b/nbs/docs/capabilities/cross_validation.ipynb
@@ -1,6 +1,16 @@
 {
  "cells": [
   {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "title: Time Series Cross Validation with NeuralForecast\n",
+    "description: Evaluate neural forecasting models with rolling time series cross validation. Configure horizons, windows, and refitting behavior in NeuralForecast.\n",
+    "---"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/nbs/docs/capabilities/cross_validation.ipynb
+++ b/nbs/docs/capabilities/cross_validation.ipynb
@@ -5,8 +5,8 @@
    "metadata": {},
    "source": [
     "---\n",
-    "title: Time Series Cross Validation with NeuralForecast\n",
-    "description: Evaluate neural forecasting models with rolling time series cross validation. Configure horizons, windows, and refitting behavior in NeuralForecast.\n",
+    "title: NeuralForecast Cross Validation API and Parameters\n",
+    "description: Understand NeuralForecast cross validation parameters, including horizons, windows, step size, validation size, test size, and refitting behavior.\n",
     "---"
    ]
   },
@@ -14,8 +14,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Cross-validation | NeuralForecast\n",
-    "\n",
     ":::{.callout-warning collapse=\"true\"}\n",
     "## Prerequesites\n",
     "This Guide assumes basic familiarity with NeuralForecast. For a minimal example visit the [Quick Start](../getting-started/quickstart.html)\n",

--- a/nbs/docs/tutorials/cross_validation.ipynb
+++ b/nbs/docs/tutorials/cross_validation.ipynb
@@ -1,6 +1,16 @@
 {
  "cells": [
   {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "title: NeuralForecast Cross Validation Tutorial in Python\n",
+    "description: Build a complete cross validation workflow in Python, compare predictions with actual values, and evaluate neural forecasting model accuracy.\n",
+    "---"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/nbs/docs/tutorials/cross_validation.ipynb
+++ b/nbs/docs/tutorials/cross_validation.ipynb
@@ -5,8 +5,8 @@
    "metadata": {},
    "source": [
     "---\n",
-    "title: NeuralForecast Cross Validation Tutorial in Python\n",
-    "description: Build a complete cross validation workflow in Python, compare predictions with actual values, and evaluate neural forecasting model accuracy.\n",
+    "title: Time Series Cross Validation Tutorial with NeuralForecast\n",
+    "description: Build a complete NeuralForecast cross validation workflow in Python, compare predictions with actual values, and evaluate models across rolling windows.\n",
     "---"
    ]
   },
@@ -14,7 +14,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Cross-validation| NeuralForecast\n",
     "> Implement cross-validation to evaluate models on historical data"
    ]
   },


### PR DESCRIPTION
## What

* Rewrites titles and descriptions for PatchTST, Temporal Fusion Transformer, Informer, iTransformer, and KAN model references.
* Adds search metadata to the NeuralForecast cross validation capability and tutorial notebooks.

## Why

These pages already receive meaningful search visibility, but terse titles do not clearly communicate forecasting intent, Python applicability, or the practical value of each reference.

## How

Each title names the model and forecasting task. Each description states the implementation value without making performance claims.

## Testing

* Parsed every changed notebook with `jq`.
* Converted both changed notebooks through `jupyter nbconvert` to validate notebook structure.
* Ran `git diff --check`.

## Checklist

* [x] Existing page routes remain unchanged.
* [x] Metadata matches current model behavior.
* [x] No benchmark or superiority claims added.
