### PR TITLE
docs: fix language errors

### DIFF
--- a/docs/models.tft.html.md
+++ b/docs/models.tft.html.md
@@ -453,7 +453,7 @@ To avoid information bottlenecks from the classic Seq2Seq architecture,
 TFT incorporates a decoder-encoder attention mechanism inherited
 transformer architectures ([Li et. al
 2019](https://arxiv.org/abs/1907.00235), [Vaswani et. al
-2017](https://arxiv.org/abs/1706.03762)). It transform the the outputs
+2017](https://arxiv.org/abs/1706.03762)). It transforms the outputs
 of the LSTM encoded temporal features, and helps the decoder better
 capture long-term relationships.
 

--- a/nbs/docs/capabilities/predictInsample.ipynb
+++ b/nbs/docs/capabilities/predictInsample.ipynb
@@ -20,7 +20,7 @@
     "\n",
     "*Use Cases*: \n",
     "* Debugging: producing insample predictions is useful for debugging purposes. For example, to check if the model is able to fit the train set.\n",
-    "* Training convergence: check if the the model has converged.\n",
+    "* Training convergence: check if the model has converged.\n",
     "* Anomaly detection: insample predictions can be used to detect anomalous behavior in the train set (e.g. outliers). (Note: if a model is too flexible it might be able to perfectly forecast outliers)"
    ]
   },

--- a/nbs/docs/tutorials/large_datasets.ipynb
+++ b/nbs/docs/tutorials/large_datasets.ipynb
@@ -14,7 +14,7 @@
    "source": [
     "The standard DataLoader class used by NeuralForecast expects the dataset to be represented by a single DataFrame, which is entirely loaded into memory when fitting the model. However, when the dataset is too large for this, we can instead use the custom large-scale DataLoader. This custom loader assumes that each timeseries is split across a collection of Parquet files, and ensure that only one batch is ever loaded into memory at a given time.\n",
     "\n",
-    "In this notebook, we will demonstrate the expected format of these files, how to train the model and and how to perform inference using this large-scale DataLoader."
+    "In this notebook, we will demonstrate the expected format of these files, how to train the model and how to perform inference using this large-scale DataLoader."
    ]
   },
   {


### PR DESCRIPTION
## What

Fixes three objective language errors in the published NeuralForecast documentation.

## Why

The current pages contain duplicated words and one incorrect verb agreement. These mistakes are visible in the rendered capability, tutorial, and TFT model pages.

## How

1. Remove duplicated “the” and “and.”
2. Change “It transform” to “It transforms.”
3. Keep the surrounding technical meaning unchanged.

## Testing

1. [x] Parsed both modified notebooks as valid JSON.
2. [x] Reviewed the complete Markdown and notebook diff.
3. [x] Confirmed no credentials or generated artifacts are included.

## Checklist

1. [x] The title follows the conventional commit format.
2. [x] The pull request is focused on one concern.
3. [x] The complete diff was reviewed.
4. [x] No secrets, credentials, or personal data are included.
