### PR TITLE
docs: fix remaining language errors

### DIFF
--- a/docs/models.tft.html.md
+++ b/docs/models.tft.html.md
@@ -414,8 +414,8 @@ complexity capable of accommodating different size datasets. As residual
 connections allow for the network to skip the non-linear transformation
 of input $\mathbf{a}$ and context $\mathbf{c}$.
 
-The Gated Linear Unit (GLU) provides the flexibility of supressing
-unnecesary parts of the GRN. Consider GRN’s output $\gamma$ then GLU
+The Gated Linear Unit (GLU) provides the flexibility of suppressing
+unnecessary parts of the GRN. Consider GRN’s output $\gamma$ then GLU
 transformation is defined by:
 
 $$\mathrm{GLU}(\gamma) = \sigma(\mathbf{W}_{4}\gamma +b_{4}) \odot (\mathbf{W}_{5}\gamma +b_{5})$$
@@ -468,4 +468,3 @@ $\mathrm{InterpretableMultiHead}(Q,K,V) = \tilde{H} W_{M}$. The
 mechanism has a great resemblence to a single attention layer, but it
 allows for $M$ multiple attention weights, and can be therefore be
 interpreted as the average ensemble of $M$ single attention layers.
-

--- a/docs/models.timesnet.html.md
+++ b/docs/models.timesnet.html.md
@@ -10,7 +10,7 @@ intraperiod and interperiod temporal variations.
 
 The architecture has the following distinctive features: - An embedding
 layer that maps the input sequence into a latent space. - Transformation
-of 1D time seires into 2D tensors, based on periods found by FFT. - A
+of 1D time series into 2D tensors, based on periods found by FFT. - A
 convolutional Inception block that captures temporal variations at
 different scales and between periods.
 

--- a/nbs/docs/capabilities/cross_validation.ipynb
+++ b/nbs/docs/capabilities/cross_validation.ipynb
@@ -15,7 +15,7 @@
    "metadata": {},
    "source": [
     ":::{.callout-warning collapse=\"true\"}\n",
-    "## Prerequesites\n",
+    "## Prerequisites\n",
     "This Guide assumes basic familiarity with NeuralForecast. For a minimal example visit the [Quick Start](../getting-started/quickstart.html)\n",
     ":::\n",
     "\n",

--- a/nbs/docs/tutorials/cross_validation.ipynb
+++ b/nbs/docs/tutorials/cross_validation.ipynb
@@ -48,7 +48,7 @@
    "metadata": {},
    "source": [
     ":::{.callout-warning collapse=\"true\"}\n",
-    "## Prerequesites\n",
+    "## Prerequisites\n",
     "This guide assumes basic familiarity with `neuralforecast`. For a minimal example visit the [Quick Start](../getting-started/quickstart.html)\n",
     ":::"
    ]

--- a/nbs/docs/tutorials/getting_started_complete.ipynb
+++ b/nbs/docs/tutorials/getting_started_complete.ipynb
@@ -16,7 +16,7 @@
    "metadata": {},
    "source": [
     ":::{.callout-warning collapse=\"true\"}\n",
-    "## Prerequesites\n",
+    "## Prerequisites\n",
     "This Guide assumes basic familiarity with NeuralForecast. For a minimal example visit the [Quick Start](../getting-started/quickstart.html)\n",
     ":::\n",
     "\n",

--- a/nbs/docs/use-cases/electricity_peak_forecasting.ipynb
+++ b/nbs/docs/use-cases/electricity_peak_forecasting.ipynb
@@ -359,7 +359,7 @@
    "metadata": {},
    "source": [
     ":::{.callout-important}\n",
-    "When using `cross_validation` make sure the forecasts are produced at the desired timestamps. Check the `cutoff` column which specifices the last timestamp before the forecasting window.\n",
+    "When using `cross_validation` make sure the forecasts are produced at the desired timestamps. Check the `cutoff` column which specifies the last timestamp before the forecasting window.\n",
     ":::"
    ]
   },

--- a/neuralforecast/models/patchtst.py
+++ b/neuralforecast/models/patchtst.py
@@ -832,7 +832,7 @@ class PatchTST(BaseModel):
         stride (int): stride of patch.
         revin (bool): bool to use RevIn.
         revin_affine (bool): bool to use affine in RevIn.
-        revin_subtract_last (bool): bool to use substract last in RevIn.
+        revin_subtract_last (bool): bool to use subtract last in RevIn.
         activation (str): activation from ['gelu','relu'].
         res_attention (bool): bool to use residual attention.
         batch_normalization (bool): bool to use batch normalization.


### PR DESCRIPTION
## What

Fix eight objective spelling errors in the published NeuralForecast documentation and model parameter text.

## Why

These mistakes are visible on the generated Nixtlaverse pages. The corrections preserve the technical meaning and change only misspelled words.

## How

1. Correct three Prerequisites headings.
2. Correct the descriptions for cutoff timestamps and RevIn.
3. Correct spelling in the TFT and TimesNet model pages.

## Testing

1. [x] Parsed all four modified notebooks as valid JSON.
2. [x] Confirmed the reported misspellings are absent from the affected files.
3. [x] Reviewed the complete diff.
4. [x] Confirmed no secrets, credentials, or generated binaries are included.

## Checklist

1. [x] The title follows the conventional commit format.
2. [x] The pull request is focused on one concern.
3. [x] The complete diff was reviewed.
4. [x] No secrets, credentials, or personal data are included.