### PR TITLE
docs: fix hyperparameter tuning typos

### DIFF
--- a/nbs/docs/capabilities/hyperparameter_tuning.ipynb
+++ b/nbs/docs/capabilities/hyperparameter_tuning.ipynb
@@ -372,7 +372,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next, we use the `Neuralforecast` class to train the `Auto` model. In this step, `Auto` models will automatically perform hyperparamter tuning training multiple models with different hyperparameters, producing the forecasts on the validation set, and evaluating them. The best configuration is selected based on the error on a validation set. Only the best model is stored and used during inference."
+    "Next, we use the `Neuralforecast` class to train the `Auto` model. In this step, `Auto` models will automatically perform hyperparameter tuning, training multiple models with different hyperparameters, producing the forecasts on the validation set, and evaluating them. The best configuration is selected based on the error on a validation set. Only the best model is stored and used during inference."
    ]
   },
   {

--- a/nbs/docs/tutorials/adding_models.ipynb
+++ b/nbs/docs/tutorials/adding_models.ipynb
@@ -175,7 +175,7 @@
     "    - `EXOGENOUS_STAT`: if the model can handle static exogenous variables (True) or not (False)\n",
     "    - `MULTIVARIATE`: If the model produces multivariate forecasts (True) or univariate (False)\n",
     "    - `RECURRENT`: If the model produces forecasts recursively (True) or direct (False)\n",
-    "5. Define the `forward` method, which recieves the input batch dictionary and returns the forecast."
+    "5. Define the `forward` method, which receives the input batch dictionary and returns the forecast."
    ]
   },
   {

--- a/nbs/docs/tutorials/forecasting_tft.ipynb
+++ b/nbs/docs/tutorials/forecasting_tft.ipynb
@@ -169,7 +169,7 @@
    "source": [
     "## 3. Model training and forecast\n",
     "\n",
-    "First, instantiate the `AutoTFT` model. The `AutoTFT` class will automatically perform hyperparamter tunning using [Tune library](https://docs.ray.io/en/latest/tune/index.html), exploring a user-defined or default search space. Models are selected based on the error on a validation set and the best model is then stored and used during inference. \n",
+    "First, instantiate the `AutoTFT` model. The `AutoTFT` class will automatically perform hyperparameter tuning using [Tune library](https://docs.ray.io/en/latest/tune/index.html), exploring a user-defined or default search space. Models are selected based on the error on a validation set and the best model is then stored and used during inference. \n",
     "\n",
     "To instantiate `AutoTFT` you need to define:\n",
     "\n",

--- a/nbs/docs/tutorials/intermittent_data.ipynb
+++ b/nbs/docs/tutorials/intermittent_data.ipynb
@@ -270,7 +270,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next, we use the `Neuralforecast` class to train the `Auto` model. In this step, `Auto` models will automatically perform hyperparamter tuning training multiple models with different hyperparameters, producing the forecasts on the validation set, and evaluating them. The best configuration is selected based on the error on a validation set. Only the best model is stored and used during inference."
+    "Next, we use the `Neuralforecast` class to train the `Auto` model. In this step, `Auto` models will automatically perform hyperparameter tuning, training multiple models with different hyperparameters, producing the forecasts on the validation set, and evaluating them. The best configuration is selected based on the error on a validation set. Only the best model is stored and used during inference."
    ]
   },
   {

--- a/nbs/docs/tutorials/longhorizon_nhits.ipynb
+++ b/nbs/docs/tutorials/longhorizon_nhits.ipynb
@@ -273,7 +273,7 @@
    "source": [
     "## 3. Hyperparameter selection and forecasting\n",
     "\n",
-    "The `AutoNHITS` class will automatically perform hyperparamter tunning using [Tune library](https://docs.ray.io/en/latest/tune/index.html), exploring a user-defined or default search space. Models are selected based on the error on a validation set and the best model is then stored and used during inference. \n",
+    "The `AutoNHITS` class will automatically perform hyperparameter tuning using [Tune library](https://docs.ray.io/en/latest/tune/index.html), exploring a user-defined or default search space. Models are selected based on the error on a validation set and the best model is then stored and used during inference. \n",
     "\n",
     "The `AutoNHITS.default_config` attribute contains a suggested hyperparameter space. Here, we specify a different search space following the paper's hyperparameters. Notice that *1000 Stochastic Gradient Steps* are enough to achieve SoTA performance. Feel free to play around with this space."
    ]

--- a/nbs/docs/tutorials/longhorizon_probabilistic.ipynb
+++ b/nbs/docs/tutorials/longhorizon_probabilistic.ipynb
@@ -299,7 +299,7 @@
    "source": [
     "## 3. Hyperparameter selection and forecasting\n",
     "\n",
-    "The `AutoNHITS` class will automatically perform hyperparamter tunning using [Tune library](https://docs.ray.io/en/latest/tune/index.html), exploring a user-defined or default search space. Models are selected based on the error on a validation set and the best model is then stored and used during inference. \n",
+    "The `AutoNHITS` class will automatically perform hyperparameter tuning using [Tune library](https://docs.ray.io/en/latest/tune/index.html), exploring a user-defined or default search space. Models are selected based on the error on a validation set and the best model is then stored and used during inference. \n",
     "\n",
     "The `AutoNHITS.default_config` attribute contains a suggested hyperparameter space. Here, we specify a different search space following the paper's hyperparameters. Notice that *1000 Stochastic Gradient Steps* are enough to achieve SoTA performance. Feel free to play around with this space."
    ]

--- a/nbs/docs/tutorials/multivariate_tsmixer.ipynb
+++ b/nbs/docs/tutorials/multivariate_tsmixer.ipynb
@@ -605,7 +605,7 @@
    "metadata": {},
    "source": [
     "## 5. Tuning the hyperparameters\n",
-    "The `AutoTSMixer` / `AutoTSMixerx` class will automatically perform hyperparamter tunning using the [Tune library](https://docs.ray.io/en/latest/tune/index.html), exploring a user-defined or default search space. Models are selected based on the error on a validation set and the best model is then stored and used during inference. \n",
+    "The `AutoTSMixer` / `AutoTSMixerx` class will automatically perform hyperparameter tuning using the [Tune library](https://docs.ray.io/en/latest/tune/index.html), exploring a user-defined or default search space. Models are selected based on the error on a validation set and the best model is then stored and used during inference. \n",
     "\n",
     "The `AutoTSMixer.default_config` / `AutoTSMixerx.default_config`  attribute contains a suggested hyperparameter space. Here, we specify a different search space following the paper's hyperparameters. Feel free to play around with this space.\n",
     "\n",


### PR DESCRIPTION
## What

Fix seven language errors in NeuralForecast tutorial notebooks.

## Why

The misspellings and missing punctuation are visible in the generated documentation for model tuning and custom model development.

## How

- Correct `hyperparamter tunning` to `hyperparameter tuning`.
- Clarify two tuning sentences with a comma.
- Correct `recieves` to `receives`.

## Testing

- [x] Parsed every modified notebook as valid JSON with `jq`.
- [x] Confirmed the corrected misspellings are absent from `nbs/docs`.
- [x] Ran `git diff --check`.
- [x] Reviewed the complete diff.
