### PR TITLE
docs: fix broken links in README and model references

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![PyPi](https://img.shields.io/pypi/v/neuralforecast?color=blue)](https://pypi.org/project/neuralforecast/)
 [![conda-nixtla](https://img.shields.io/conda/vn/conda-forge/neuralforecast?color=seagreen&label=conda)](https://anaconda.org/conda-forge/neuralforecast)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/Nixtla/neuralforecast/blob/main/LICENSE)
-[![docs](https://img.shields.io/website-up-down-green-red/http/nixtla.github.io/neuralforecast.svg?label=docs)](https://nixtla.github.io/neuralforecast/)
+[![docs](https://img.shields.io/website-up-down-green-red/https/nixtlaverse.nixtla.io/neuralforecast.svg?label=docs)](https://nixtlaverse.nixtla.io/neuralforecast/)
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-11-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
@@ -132,7 +132,7 @@ If you enjoy or benefit from using these Python implementations, a citation to t
 
 ## Contributors ✨
 
-Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/en/reference/emoji-key/)):
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->
 <!-- markdownlint-disable -->

--- a/neuralforecast/models/dlinear.py
+++ b/neuralforecast/models/dlinear.py
@@ -85,7 +85,7 @@ class DLinear(BaseModel):
         **trainer_kwargs (int):  keyword trainer arguments inherited from [PyTorch Lighning's trainer](https://pytorch-lightning.readthedocs.io/en/stable/api/pytorch_lightning.trainer.trainer.Trainer.html?highlight=trainer).
 
     References:
-        - [Zeng, Ailing, et al. "Are transformers effective for time series forecasting?." Proceedings of the AAAI conference on artificial intelligence. Vol. 37. No. 9. 2023."](https://ojs.aaai.org/index.php/AAAI/article/view/27695)
+        - [Zeng, Ailing, et al. "Are transformers effective for time series forecasting?." Proceedings of the AAAI conference on artificial intelligence. Vol. 37. No. 9. 2023."](https://ojs.aaai.org/index.php/AAAI/article/view/26317)
     """
 
     # Class attributes

--- a/neuralforecast/models/nlinear.py
+++ b/neuralforecast/models/nlinear.py
@@ -49,7 +49,7 @@ class NLinear(BaseModel):
         **trainer_kwargs (int):  keyword trainer arguments inherited from [PyTorch Lighning's trainer](https://pytorch-lightning.readthedocs.io/en/stable/api/pytorch_lightning.trainer.trainer.Trainer.html?highlight=trainer).
 
     References:
-        - [Zeng, Ailing, et al. "Are transformers effective for time series forecasting?." Proceedings of the AAAI conference on artificial intelligence. Vol. 37. No. 9. 2023."](https://ojs.aaai.org/index.php/AAAI/article/view/27695)
+        - [Zeng, Ailing, et al. "Are transformers effective for time series forecasting?." Proceedings of the AAAI conference on artificial intelligence. Vol. 37. No. 9. 2023."](https://ojs.aaai.org/index.php/AAAI/article/view/26317)
     """
 
     # Class attributes


### PR DESCRIPTION
## Description

Fixes four broken links: the docs badge and the emoji-key link in the README, and the AAAI reference in the `DLinear`/`NLinear` docstrings.

**1. Docs badge points at the retired site (`README.md:16`)**

`nixtla.github.io/neuralforecast` is no longer served and returns 404. This affects the badge twice: the link goes nowhere, and because shields.io probes that same URL for its up/down state, the badge currently renders red. The badge SVG served today reports `aria-label="docs: down"`; with the URL updated it reports `aria-label="docs: up"`.

`README.md:58` already links to `nixtlaverse.nixtla.io`, so this looks like the one spot the docs migration missed — it is the only remaining `nixtla.github.io` reference in the repository. The probe protocol is also bumped from `http` to `https` to match.

**2. AAAI reference points at the wrong article (`dlinear.py:88`, `nlinear.py:52`)**

Both docstrings cite Zeng et al., *Are Transformers Effective for Time Series Forecasting?* but link `AAAI/article/view/27695`, which 404s.

The correct article ID is `26317`. Verified via Crossref — DOI `10.1609/aaai.v37i9.26317` resolves to:

- title: `Are Transformers Effective for Time Series Forecasting?`
- authors: Zeng, Chen, Zhang, Xu
- *Proceedings of the AAAI Conference on Artificial Intelligence*, 2023, pp. 11121–11128

The volume and issue (`v37i9`) match the `Vol. 37. No. 9. 2023` already written in the citation text, and `https://ojs.aaai.org/index.php/AAAI/article/view/26317` returns 200.

**3. all-contributors emoji key (`README.md:135`)**

`allcontributors.org/docs/en/emoji-key` 404s. This uses the current canonical URL `https://allcontributors.org/en/reference/emoji-key/` (200) rather than a URL that merely redirects. The line sits outside the `ALL-CONTRIBUTORS-LIST` markers, so the bot will not overwrite it.

## How I checked

Extracted every http(s) URL from the repository's Markdown and Python files and resolved each with `curl -L`, keeping only genuine 404s — redirects that still resolve were left alone. The AAAI article ID was confirmed against Crossref rather than by guessing an offset. Both badge states were read from the live shields.io SVG.

Documentation only — the two Python changes are inside docstrings, `python -m py_compile` passes on both, and no functional code is touched.

_Disclosure: prepared with AI assistance; every link and the article identity were verified manually._
