### PR TITLE
fix: preserve infinite losses in weighted reductions

### DIFF
--- a/neuralforecast/losses/pytorch.py
+++ b/neuralforecast/losses/pytorch.py
@@ -33,13 +33,14 @@ def _divide_no_nan(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
     Auxiliary function to handle divide by 0
     """
     div = a / b
-    return torch.nan_to_num(div, nan=0.0, posinf=0.0, neginf=0.0)
+    return torch.nan_to_num(div, nan=0.0, posinf=float("inf"), neginf=float("-inf"))
 
 
 def _weighted_mean(losses, weights):
     """
     Compute weighted mean of losses per datapoint.
     """
+    losses = torch.where(weights != 0, losses, 0.0)
     return _divide_no_nan(torch.sum(losses * weights), torch.sum(weights))
 
 

--- a/tests/test_losses/test_pytorch.py
+++ b/tests/test_losses/test_pytorch.py
@@ -110,6 +110,16 @@ def test_MAE_complete_mask():
     assert loss == (3 / 6), "Should be 3/6"
 
 
+def test_MAE_infinite_predictions():
+    y = torch.tensor([[[10.0], [20.0]]])
+    mask = torch.tensor([[[1.0], [0.0]]])
+
+    for prediction in [float("inf"), float("-inf")]:
+        y_hat = torch.full_like(y, prediction)
+        assert torch.isposinf(MAE()(y=y, y_hat=y_hat))
+        assert torch.isposinf(MAE()(y=y, y_hat=y_hat, mask=mask))
+
+
 # Incomplete mask and complete horizon_weight
 def test_MAE_incomplete_mask():
     # Only 1 error and points is masked.


### PR DESCRIPTION
Title: fix: preserve infinite losses in weighted reductions

## Summary

- Preserve signed infinities in `_divide_no_nan` instead of replacing them with zero.
- Ignore zero-weight entries before multiplying weighted losses, preventing masked infinities from producing `NaN`.
- Cover unmasked and masked positive/negative infinite predictions with an MAE regression test.

Fixes #1601

## Test evidence

- `pytest tests/test_losses/test_pytorch.py::test_MAE_infinite_predictions -q` — 1 passed
- `pytest tests/test_losses/test_pytorch.py -q` — 16 passed
- `ruff check neuralforecast/losses/pytorch.py tests/test_losses/test_pytorch.py` — passed
- `git diff --check` — passed

## Risks or notes for maintainers

`_weighted_mean` is shared by point losses, so zero-weight non-finite values are now ignored consistently wherever masks or zero horizon weights are used. No public API or dependency changes are included.
