### PR TITLE
[FEAT] Add future exogenous covariates support to iTransformer

### DIFF
--- a/neuralforecast/models/itransformer.py
+++ b/neuralforecast/models/itransformer.py
@@ -29,7 +29,10 @@ class iTransformer(BaseModel):
         h (int): Forecast horizon.
         input_size (int): autorregresive inputs size, y=[1,2,3,4] input_size=2 -> y_[t-2:t]=[1,2].
         n_series (int): number of time-series.
-        futr_exog_list (str list): future exogenous columns.
+        futr_exog_list (str list, optional): future exogenous columns known ahead across the forecast horizon.
+            Each future covariate sequence over the forecast horizon `h` is embedded as an inverted token
+            via a linear projection layer, allowing cross-variable self-attention between target series and
+            future covariates.
         hist_exog_list (str list): historic exogenous columns.
         stat_exog_list (str list): static exogenous columns.
         exclude_insample_y (bool): the model skips the autoregressive features y[t-input_size:t] if True.
@@ -72,7 +75,7 @@ class iTransformer(BaseModel):
     """
 
     # Class attributes
-    EXOGENOUS_FUTR = False
+    EXOGENOUS_FUTR = True
     EXOGENOUS_HIST = False
     EXOGENOUS_STAT = False
     MULTIVARIATE = True
@@ -170,9 +173,15 @@ class iTransformer(BaseModel):
         self.use_norm = use_norm
 
         # Architecture
+        # Inverted embedding for target series: projects lookback length (input_size) -> hidden_size
         self.enc_embedding = DataEmbedding_inverted(
             input_size, self.hidden_size, self.dropout
         )
+
+        # Inverted embedding for future exogenous variables: projects horizon length (h) -> hidden_size
+        if self.futr_exog_size > 0:
+            self.futr_embedding = nn.Linear(h, self.hidden_size)
+            self.futr_dropout = nn.Dropout(self.dropout)
 
         self.encoder = TransEncoder(
             [
@@ -198,7 +207,17 @@ class iTransformer(BaseModel):
             self.hidden_size, h * self.loss.outputsize_multiplier, bias=True
         )
 
-    def forecast(self, x_enc):
+    def forecast(self, x_enc, futr_exog=None):
+        """Generate forecasts from lookback series and optional future covariates.
+
+        Args:
+            x_enc (torch.Tensor): Lookback target sequences of shape [batch_size, input_size, n_series].
+            futr_exog (torch.Tensor, optional): Future exogenous covariates of shape
+                [batch_size, futr_exog_size, input_size + h, n_series].
+
+        Returns:
+            dec_out (torch.Tensor): Forecast tensor of shape [batch_size, h * outputsize_multiplier, n_series].
+        """
         if self.use_norm:
             # Normalization from Non-stationary Transformer
             means = x_enc.mean(1, keepdim=True).detach()
@@ -208,25 +227,41 @@ class iTransformer(BaseModel):
             )
             x_enc /= stdev
 
-        _, _, N = x_enc.shape  # B L N
-        # B: batch_size;       E: hidden_size;
-        # L: input_size;       S: horizon(h);
-        # N: number of variate (tokens), can also includes covariates
+        _, _, N = x_enc.shape  # B: batch_size, L: input_size, N: n_series
 
-        # Embedding
-        # B L N -> B N E                (B L N -> B L E in the vanilla Transformer)
-        enc_out = self.enc_embedding(
-            x_enc, None
-        )  # covariates (e.g timestamp) can be also embedded as tokens
+        # Inverted embedding for target series: B L N -> B N E
+        enc_out = self.enc_embedding(x_enc, None)
 
-        # B N E -> B N E                (B L E -> B L E in the vanilla Transformer)
-        # the dimensions of embedded time series has been inverted, and then processed by native attn, layernorm and ffn modules
-        enc_out, attns = self.encoder(enc_out, attn_mask=None)
+        # Inverted embedding for future exogenous variables
+        if self.futr_exog_size > 0 and futr_exog is not None:
+            if futr_exog.ndim == 3:
+                futr_exog = futr_exog.unsqueeze(-1)
 
-        # B N E -> B N S -> B S N
-        dec_out = self.projector(enc_out).permute(0, 2, 1)[
-            :, :, :N
-        ]  # filter the covariates
+            # Extract future horizon: [B, F, L + h, N] -> [B, F, h, N]
+            futr = futr_exog[:, :, self.input_size :, :]
+            B_f, F_f, h_f, N_f = futr.shape
+
+            # Reshape each feature for each series as a token: [B, N * F, h]
+            futr = futr.permute(0, 3, 1, 2).reshape(B_f, N_f * F_f, h_f)
+
+            if self.use_norm:
+                f_means = futr.mean(-1, keepdim=True).detach()
+                futr = futr - f_means
+                f_stdev = torch.sqrt(
+                    torch.var(futr, dim=-1, keepdim=True, unbiased=False) + 1e-5
+                )
+                futr /= f_stdev
+
+            futr_tokens = self.futr_dropout(self.futr_embedding(futr))
+            tokens = torch.cat([enc_out, futr_tokens], dim=1)
+        else:
+            tokens = enc_out
+
+        # Inverted Transformer encoder: attention across variates
+        enc_out, attns = self.encoder(tokens, attn_mask=None)
+
+        # Project only the first N tokens (target series) to forecast horizon
+        dec_out = self.projector(enc_out[:, :N, :]).permute(0, 2, 1)
 
         if self.use_norm:
             # De-Normalization from Non-stationary Transformer
@@ -244,9 +279,11 @@ class iTransformer(BaseModel):
         return dec_out
 
     def forward(self, windows_batch):
+        # Extract lookback targets [B, L, N] and future covariates [B, F, L + h, N]
         insample_y = windows_batch["insample_y"]
+        futr_exog = windows_batch.get("futr_exog", None)
 
-        y_pred = self.forecast(insample_y)
+        y_pred = self.forecast(insample_y, futr_exog=futr_exog)
         y_pred = y_pred.reshape(insample_y.shape[0], self.h, -1)
 
         return y_pred

--- a/tests/test_models/test_itransformer.py
+++ b/tests/test_models/test_itransformer.py
@@ -32,3 +32,72 @@ def test_autoitransformer(setup_dataset):
     my_config['hidden_size'] = 16
     model = AutoiTransformer(h=12, n_series=1, config=my_config, backend='ray', num_samples=1, ray_options=RayOptions(cpus=1))
     model.fit(dataset=setup_dataset)
+
+
+def test_itransformer_futr_exog(suppress_warnings):
+    import pandas as pd
+    from neuralforecast import NeuralForecast
+    from neuralforecast.utils import generate_series
+
+    assert iTransformer.EXOGENOUS_FUTR
+
+    # Multivariate test with future exogenous
+    n_series = 2
+    h = 12
+    input_size = 24
+
+    df = generate_series(
+        n_series=n_series,
+        n_temporal_features=2,
+        seed=42,
+        freq="D",
+        equal_ends=True,
+        max_length=60,
+    )
+    max_ds = df.ds.max() - pd.Timedelta(h, "D")
+    train_df = df[df.ds < max_ds]
+    test_df = df[df.ds >= max_ds]
+
+    model = iTransformer(
+        h=h,
+        input_size=input_size,
+        n_series=n_series,
+        futr_exog_list=["temporal_0", "temporal_1"],
+        max_steps=5,
+        val_check_steps=5,
+    )
+
+    nf = NeuralForecast(models=[model], freq="D")
+    nf.fit(df=train_df)
+    preds = nf.predict(futr_df=test_df)
+
+    assert not preds.isnull().values.any()
+    assert len(preds) == n_series * h
+
+    # Univariate test with future exogenous
+    df_uni = generate_series(
+        n_series=1,
+        n_temporal_features=1,
+        seed=42,
+        freq="D",
+        equal_ends=True,
+        max_length=60,
+    )
+    max_ds_uni = df_uni.ds.max() - pd.Timedelta(h, "D")
+    train_uni = df_uni[df_uni.ds < max_ds_uni]
+    test_uni = df_uni[df_uni.ds >= max_ds_uni]
+
+    model_uni = iTransformer(
+        h=h,
+        input_size=input_size,
+        n_series=1,
+        futr_exog_list=["temporal_0"],
+        max_steps=5,
+        val_check_steps=5,
+    )
+    nf_uni = NeuralForecast(models=[model_uni], freq="D")
+    nf_uni.fit(df=train_uni)
+    preds_uni = nf_uni.predict(futr_df=test_uni)
+
+    assert not preds_uni.isnull().values.any()
+    assert len(preds_uni) == 1 * h


### PR DESCRIPTION
## Description
This PR completes the support for future exogenous covariates (`futr_exog`) in the `iTransformer` model.

### Context & Motivation
`iTransformer.__init__` already accepted `futr_exog_list` in its signature, indicating planned support for future covariates. However, the model did not yet implement the inverted tokenization or projection for future exogenous variables, and `EXOGENOUS_FUTR` was left disabled.

This PR finishes the integration cleanly within the inverted Transformer architecture:
1. **Horizon Slicing & Inverted Embedding:** Future covariates are extracted over the forecast horizon ($h$) and each feature per series is projected via `futr_embedding = nn.Linear(h, hidden_size)` into its own token of shape `[batch_size, n_series * futr_exog_size, hidden_size]`.
2. **Cross-Variate Attention:** Covariate tokens are concatenated with target series tokens `[enc_out, futr_tokens]` before passing through the inverted Transformer encoder (`TransEncoder`), allowing self-attention across variates and future drivers.
3. **Target Forecast Projection:** Only the first $N$ target series tokens (`enc_out[:, :N, :]`) are projected through `projector` to generate the forecast horizon, filtering out covariate tokens while preserving the standard output shape `[batch_size, h * outputsize_multiplier, n_series]`.
4. **Reversible Instance Normalization:** Reversible normalization (`use_norm`) is consistently applied to both target lookback sequences and future covariate slices, and inverted on output forecasts.

### Backward Compatibility
- 100% backward compatible: when `futr_exog_list=None`, behavior and outputs are identical to the original implementation.
- All existing tests (including `test_itransformer_model`) pass without changes.

### Tests
Added `test_itransformer_futr_exog` in `tests/test_models/test_itransformer.py` covering:
- Multivariate panel forecasting (2 series, 2 future exogenous features) with end-to-end `fit` and `predict(futr_df)`.
- Univariate panel forecasting (1 series, 1 future exogenous feature).
- Validation of output shapes and absence of `NaN` values.

### Linting
- `ruff`: no issues on modified files.
- `mypy`: 97 pre-existing errors across the codebase, none introduced by this PR (`neuralforecast/models/itransformer.py` is clean).